### PR TITLE
Return empty list if priority data is not available. Fixes issue #5.

### DIFF
--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -63,6 +63,11 @@ def transmission_get_speed_limit(resume_data, key):
 def transmission_get_file_prorities(resume_data):
     priority = resume_data.get(b"priority")
     dnd = resume_data.get(b"dnd")
+
+    # Return empty list if priority data is not available
+    if priority is None or dnd is None:
+        return []
+
     rv = []
     if len(priority) != len(dnd):
         raise ConversionError(


### PR DESCRIPTION
This PR fixes issue #5 by checking that if `priority` or `dnd` are `None`,  return an empty list if they are.