### PR TITLE
Add torrent completion status & various fixes and improvements

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,8 @@
             "request": "launch",
             "program": "transmission2qbt.py",
             "console": "integratedTerminal",
-            "args": "${command:pickArgs}"
+            "args": "${command:pickArgs}",
+            "sudo": true
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,8 +10,7 @@
             "request": "launch",
             "program": "transmission2qbt.py",
             "console": "integratedTerminal",
-            "args": "${command:pickArgs}",
-            "sudo": true
+            "args": "${command:pickArgs}"
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "transmission2qbt",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "transmission2qbt.py",
+            "console": "integratedTerminal",
+            "args": "${command:pickArgs}"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "python.analysis.extraPaths": [
+        "venv/lib/python3.12/site-packages"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -113,14 +113,14 @@ then the location you want is `${profile_dir}/qBittorrent/data/BT_backup`.
 ## Download progress
 
 qBittorrent and Transmission have a different approach to storing information about what data is already on disk:
-* Transmission keeps track of the status of each 16KiB block (in `resume[b"progress"][b"blocks]`, which is a bitmask where each bit represents a block). The state of each piece is not explicity stored in the resume file (but is implicitly there since each piece is made of 2^n consecutive blocks).
+* Transmission keeps track of the status of each 16KiB block (in `resume[b"progress"][b"blocks]`, which is a bitmask where each bit represents a block). The state of each piece is not explicity stored in the resume file (but is implicitly there since each piece is made of consecutive blocks).
 * qBittorrent keeps track separately of:
   * Which pieces are complete (in `resume[b"pieces"]`).
   * Which blocks are complete in each incomplete piece (in `resume[b"unfinished"]`).
 With this in mind, **this script only concerns itself with complete pieces**, i.e. the `pieces` section of the qBittorrent resume file is calculated but the `unfinished` section is omitted.
 It should be possible to build it, but:
 - This would almost certainly significantly slow down the script. The pieces calculation only leverages data in the resume files, but calculating the unfinished field requires computing checksums of the actual torrent data (see the adler32 checksum in [the spec](https://github.com/steeve/libtorrent/blob/master/docs/manual.rst#fast-resume)).
-- The only effect of not calculating the field is to **discard partially downloaded pieces**. This should always be a very low amount of data for qBittorrent to download again.
+- The only effect of not calculating the field is to **discard partially downloaded pieces**. This should generally be a negligible amount of data for qBittorrent to download again.
 - As a workaround, force-rechecking all incomplete torrents once the migration is complete should recover the information (not tested).
 
 ## Incomplete files

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ qBittorrent and Transmission have a different approach to storing information ab
 * qBittorrent keeps track separately of:
   * Which pieces are complete (in `resume[b"pieces"]`).
   * Which blocks are complete in each incomplete piece (in `resume[b"unfinished"]`).
+
 With this in mind, **this script only concerns itself with complete pieces**, i.e. the `pieces` section of the qBittorrent resume file is calculated but the `unfinished` section is omitted.
 It should be possible to build it, but:
     - This would almost certainly significantly slow down the script. The pieces calculation only leverages data in the resume files, but calculating the unfinished field requires computing checksums of the actual torrent data (see the adler32 checksum in [the spec](https://github.com/steeve/libtorrent/blob/master/docs/manual.rst#fast-resume)).

--- a/README.md
+++ b/README.md
@@ -57,18 +57,14 @@ Shut down both Transmission and qBittorrent and do :
 
 ## Predicate
 
-The `--predicate` argument accepts a Python expression that can be used for
-filtering torrents which are going to be imported to qBt. The parsed torrent
-file is named `torrent.value` and its associated Transmission resume data is
-`resume.value`. If the expression returns anything other than `True` or throws
-an exception, the torrent is skipped.
+The `--predicate` argument accepts a Python expression that can be used for filtering torrents which are going to be imported to qBt. The parsed torrent file is named `torrent` and its associated Transmission resume data is `resume`. If the expression returns anything other than `True` or throws an exception, the torrent is skipped.
+Access to data is done with helper methods get(type, key) for dicts and get(type, index) and cast(type) for lists. For more information check the BencodeList and BencodeType class documentation in the script.
 
 For example, this will only cause torrents using Debian's tracker whose name
 includes `amd64` to be imported :
 
 ```
-torrent.value[b'announce'] == b'http://bttracker.debian.org:6969/announce'
-and b'amd64' in torrent.value[b'info'][b'name']
+torrent.get(bytes, b'announce') == b'http://bttracker.debian.org:6969/announce' and b'amd64' in torrent.get(BencodeType, b'info').get(bytes, b'name')
 ```
 
 # Mappings

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ for the *Resume data storage type (requires restart)* setting should be
 script so qBittorrent can export any existing data from SQLite and switches to
 Fastresume before starting the migration from Transmission.
 
+Python 3.12 or over must be installed in the environment where the script is run.
+
 ## Invocation
 
 From the root of the folder

--- a/README.md
+++ b/README.md
@@ -135,9 +135,9 @@ qBittorrent and Transmission have a different approach to storing information ab
   * Which blocks are complete in each incomplete piece (in `resume[b"unfinished"]`).
 With this in mind, **this script only concerns itself with complete pieces**, i.e. the `pieces` section of the qBittorrent resume file is calculated but the `unfinished` section is omitted.
 It should be possible to build it, but:
-- This would almost certainly significantly slow down the script. The pieces calculation only leverages data in the resume files, but calculating the unfinished field requires computing checksums of the actual torrent data (see the adler32 checksum in [the spec](https://github.com/steeve/libtorrent/blob/master/docs/manual.rst#fast-resume)).
-- The only effect of not calculating the field is to **discard partially downloaded pieces**. This should generally be a negligible amount of data for qBittorrent to download again.
-- As a workaround, force-rechecking all incomplete torrents once the migration is complete should recover the information (not tested).
+    - This would almost certainly significantly slow down the script. The pieces calculation only leverages data in the resume files, but calculating the unfinished field requires computing checksums of the actual torrent data (see the adler32 checksum in [the spec](https://github.com/steeve/libtorrent/blob/master/docs/manual.rst#fast-resume)).
+    - The only effect of not calculating the field is to **discard partially downloaded pieces**. This should generally be a negligible amount of data for qBittorrent to download again.
+    - As a workaround, force-rechecking all incomplete torrents once the migration is complete should recover the information (not tested).
 
 ## Incomplete files
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Python is not my native language, so please bear with me.
 Most of the tools I could find simply used qBt's Web API to import torrents.
 This is fine for most usages but I wanted to keep some of the metadata that's
 saved in resume files, notably the original "added date" as well as the amount
-of data transferred so far.
+of data transferred so far and the completion state of the torrent.
 
 # Tested combinations
 
@@ -59,16 +59,16 @@ Shut down both Transmission and qBittorrent and do :
 
 The `--predicate` argument accepts a Python expression that can be used for
 filtering torrents which are going to be imported to qBt. The parsed torrent
-file is named `parsed_tor` and its associated Transmission resume data is
-`resume_data`. If the expression returns anything other than `True` or throws
+file is named `torrent.value` and its associated Transmission resume data is
+`resume.value`. If the expression returns anything other than `True` or throws
 an exception, the torrent is skipped.
 
 For example, this will only cause torrents using Debian's tracker whose name
 includes `amd64` to be imported :
 
 ```
-parsed_tor[b'announce'] == b'http://bttracker.debian.org:6969/announce'
-and b'amd64' in parsed_tor[b'info'][b'name']
+torrent.value[b'announce'] == b'http://bttracker.debian.org:6969/announce'
+and b'amd64' in torrent.value[b'info'][b'name']
 ```
 
 # Mappings
@@ -110,11 +110,22 @@ then the location you want is `${profile_dir}/qBittorrent/data/BT_backup`.
 
 # Limitations
 
-* I couldn't figure out how to import Transmission data about the already
-available pieces, which means that all torrents will automatically be re-checked
-when qBittorrent is first run after the migration.
+## Download progress
 
-* If your Transmission is set to append `.part` to incomplete files, make sure
+qBittorrent and Transmission have a different approach to storing information about what data is already on disk:
+* Transmission keeps track of the status of each 16KiB block (in `resume[b"progress"][b"blocks]`, which is a bitmask where each bit represents a block). The state of each piece is not explicity stored in the resume file (but is implicitly there since each piece is made of 2^n consecutive blocks).
+* qBittorrent keeps track separately of:
+  * Which pieces are complete (in `resume[b"pieces"]`).
+  * Which blocks are complete in each incomplete piece (in `resume[b"unfinished"]`).
+With this in mind, **this script only concerns itself with complete pieces**, i.e. the `pieces` section of the qBittorrent resume file is calculated but the `unfinished` section is omitted.
+It should be possible to build it, but:
+- This would almost certainly significantly slow down the script. The pieces calculation only leverages data in the resume files, but calculating the unfinished field requires computing checksums of the actual torrent data.
+- The only effect of not calculating the field is to **discard partially downloaded pieces**. This should always be a very low amount of data for qBittorrent to download again.
+- As a workaround, force-rechecking all incomplete torrents once the migration is complete should recover the information (not tested).
+
+## Incomplete files
+
+If your Transmission is set to append `.part` to incomplete files, make sure
 you remove that suffix before running the migration, otherwise qBittorrent won't
 detect those files at all. Once qBt detects that a file is incomplete, it will
 append `.!qBt` itself if that option is enabled. This command will remove the

--- a/README.md
+++ b/README.md
@@ -49,15 +49,33 @@ Fastresume before starting the migration from Transmission.
 
 ## Invocation
 
-Shut down both Transmission and qBittorrent and do :
+From the root of the folder
+
+1. (First time only) Create a virtual Python environment:
+```
+python -m venv venv
+```
+(you might have to do this first call with `python3` depending on your environment)
+
+1. (First time only) Install the prerequisites in the venv:
+```
+pip install -r requirements.txt
+```
+
+1. Shut down both Transmission and qBittorrent
+2. Run:
 
 ```
 ./transmission2qbt.py ~/.config/transmission ~/.local/share/data/qBittorrent/BT_backup
 ```
+For help including information about the supported parameters, run:
+```
+./transmission2qbt.py --help
+```
 
-## Predicate
+## Filter
 
-The `--predicate` argument accepts a Python expression that can be used for filtering torrents which are going to be imported to qBt. The parsed torrent file is named `torrent` and its associated Transmission resume data is `resume`. If the expression returns anything other than `True` or throws an exception, the torrent is skipped.
+The `--filter`/`f` argument accepts a Python expression that can be used for filtering torrents which are going to be imported to qBt. The parsed torrent file is named `torrent` and its associated Transmission resume data is `resume`. If the expression returns anything other than `True` or throws an exception, the torrent is skipped.
 Access to data is done with helper methods get(type, key) for dicts and get(type, index) and cast(type) for lists. For more information check the BencodeList and BencodeType class documentation in the script.
 
 For example, this will only cause torrents using Debian's tracker whose name

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ qBittorrent and Transmission have a different approach to storing information ab
   * Which blocks are complete in each incomplete piece (in `resume[b"unfinished"]`).
 With this in mind, **this script only concerns itself with complete pieces**, i.e. the `pieces` section of the qBittorrent resume file is calculated but the `unfinished` section is omitted.
 It should be possible to build it, but:
-- This would almost certainly significantly slow down the script. The pieces calculation only leverages data in the resume files, but calculating the unfinished field requires computing checksums of the actual torrent data.
+- This would almost certainly significantly slow down the script. The pieces calculation only leverages data in the resume files, but calculating the unfinished field requires computing checksums of the actual torrent data (see the adler32 checksum in [the spec](https://github.com/steeve/libtorrent/blob/master/docs/manual.rst#fast-resume)).
 - The only effect of not calculating the field is to **discard partially downloaded pieces**. This should always be a very low amount of data for qBittorrent to download again.
 - As a workaround, force-rechecking all incomplete torrents once the migration is complete should recover the information (not tested).
 

--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ qBittorrent and Transmission have a different approach to storing information ab
 
 With this in mind, **this script only concerns itself with complete pieces**, i.e. the `pieces` section of the qBittorrent resume file is calculated but the `unfinished` section is omitted.
 It should be possible to build it, but:
-    - This would almost certainly significantly slow down the script. The pieces calculation only leverages data in the resume files, but calculating the unfinished field requires computing checksums of the actual torrent data (see the adler32 checksum in [the spec](https://github.com/steeve/libtorrent/blob/master/docs/manual.rst#fast-resume)).
-    - The only effect of not calculating the field is to **discard partially downloaded pieces**. This should generally be a negligible amount of data for qBittorrent to download again.
-    - As a workaround, force-rechecking all incomplete torrents once the migration is complete should recover the information (not tested).
+- This would almost certainly significantly slow down the script. The pieces calculation only leverages data in the resume files, but calculating the unfinished field requires computing checksums of the actual torrent data (see the adler32 checksum in [the spec](https://github.com/steeve/libtorrent/blob/master/docs/manual.rst#fast-resume)).
+- The only effect of not calculating the field is to **discard partially downloaded pieces**. This should generally be a negligible amount of data for qBittorrent to download again.
+- As a workaround, force-rechecking all incomplete torrents once the migration is complete should recover the information (not tested).
 
 ## Incomplete files
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ For example, this will only cause torrents using Debian's tracker whose name
 includes `amd64` to be imported :
 
 ```
-torrent.get(bytes, b'announce') == b'http://bttracker.debian.org:6969/announce' and b'amd64' in torrent.get(BencodeType, b'info').get(bytes, b'name')
+torrent.get(bytes, b'announce') == b'http://bttracker.debian.org:6969/announce' and b'amd64' in torrent.get(BencodeDict, b'info').get(bytes, b'name')
 ```
 
 # Mappings

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 bencode.py==4.0.0
+humanize==4.15.0

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -242,10 +242,10 @@ def transmission_get_limit(resume: BencodeDict, limit_kind: str) -> int:
 #
 # The piece size is a multiple of the block size, but not always a multiple of 8*16KiB (the data chunk represented by a tr_blocks byte).
 # Which means that a tr_blocks byte might represent more than one qb_pieces byte, and vice versa; it also means that the first block of each
-# piece will not necessarily be aligned with the leftmost bit of a tr_blocks byte.
+# piece will not necessarily be aligned with the leftmost bit of a tr_blocks byte, or the last block with the rightmost bit of a byte.
 #
-# So to understand which pieces are fully on disk (which is what we need to build qb_pieces), we need to extract piece_blocks for each piece
-# in tr_blocks, and check if they are all 1.
+# So to understand which pieces are fully on disk (which is what we need in order to build qb_pieces), we need to extract piece_blocks for
+# each piece in tr_blocks, and check if they are all 1.
 # We start by finding what tr_block byte the piece starts and ends with. It might start midway through a byte (i.e. not the leftmost bit of
 # the start byte) and likewise it might end midway through a byte (not the rightmost bit of the end byte). For this reason the first and last
 # byte are checked using a bitwise masking operation, with a precalculated dict of masks indexed with the order of the first and last bit.
@@ -400,14 +400,18 @@ def map_resume_to_qbt(
             resume, b"sequentialDownload", int, default=0
         ).value,
         b"file_priority": list(transmission_get_file_priorities(resume)),
-        b"peers": transmission_get_peers(resume, 4, b"peers2"),
-        b"peers6": transmission_get_peers(resume, 16, b"peers2-6"),
         b"qBt-name": name,
         b"qBt-ratioLimit": transmission_get_limit(resume, "ratio"),
         b"qBt-inactiveSeedingTimeLimit": int(transmission_get_limit(resume, "idle")),
         b"qBt-savePath": get_child(resume, b"destination", bytes).value,
         b"pieces": transmission_get_pieces(torrent, resume),
     }
+
+    info = get_child(torrent, b"info", dict[bytes, BencodeType])
+    private, _ = get_child(info, b"private", int, default=0)
+    if not private:
+        qbt_resume_data[b"peers"] = transmission_get_peers(resume, 4, b"peers2")
+        qbt_resume_data[b"peers6"] = transmission_get_peers(resume, 16, b"peers2-6")
 
     group = get_child(resume, b"group", bytes, optional=True)
     if group is not None:

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -67,8 +67,14 @@ def get_child[T: BencodeType](
     parent: BencodeNode[dict[bytes, BencodeType]],
     child_name: bytes,
     child_type: type[T],
+) -> BencodeNode[T]: ...
+@overload
+def get_child[T: BencodeType](
+    parent: BencodeNode[dict[bytes, BencodeType]],
+    child_name: bytes,
+    child_type: type[T],
     *,
-    default: T | None = None,
+    default: T,
 ) -> BencodeNode[T]: ...
 @overload
 def get_child[T: BencodeType](

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -326,7 +326,7 @@ def transmission_get_pieces(torrent: BencodeDict, resume: BencodeDict) -> bytes:
         raise ConversionError(
             f"Piece size {piece_size} is not a multiple of {naturalsize(BLOCK_SIZE, binary=True)}, aborting"
         )
-    
+
     blocks_per_piece = piece_size // BLOCK_SIZE
     # ceiling integer division
     num_pieces = -(-torrent_size // piece_size)
@@ -451,13 +451,12 @@ class TransmissionQbtImporter:
         info_hash: str,
         torrent: BencodeDict,
         resume: BencodeDict,
-        dry_run: bool,
     ) -> None:
         qbt_resume_data = map_resume_to_qbt(info_hash, torrent, resume)
         qbt_resume_enc = bencode(qbt_resume_data)
         qbt_resume_path = os.path.join(self._target_dir, info_hash + ".fastresume")
         qbt_torrent_path = os.path.join(self._target_dir, info_hash + ".torrent")
-        if dry_run:
+        if self._dry_run:
             logging.info(
                 f"dry run: would save {naturalsize(len(qbt_resume_enc), binary=True)} to {qbt_resume_path}"
             )
@@ -505,9 +504,7 @@ class TransmissionQbtImporter:
                 return
 
         if predicate_rv is True:
-            self.copy_to_target(
-                source_tor_abs_path, info_hash, torrent, resume, self._dry_run
-            )
+            self.copy_to_target(source_tor_abs_path, info_hash, torrent, resume)
         else:
             logging.info(
                 f"Predicate returned {predicate_rv} for torrent {info_hash}, skipping"

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -35,9 +35,7 @@ class QbtUsesSqliteForResumeError(RuntimeError):
     pass
 
 
-type BencodeList = list[BencodeType]
-type BencodeDict = dict[bytes, BencodeType]
-type BencodeType = bytes | int | BencodeList | BencodeDict
+type BencodeType = bytes | int | list[BencodeType] | dict[bytes, BencodeType]
 
 
 @dataclass(frozen=True)
@@ -48,7 +46,7 @@ class BencodeNode[T: BencodeType](NamedTuple):
     path: str
 
 
-type BencodeDictNode = BencodeNode[BencodeDict]
+type BencodeDict = BencodeNode[dict[bytes, BencodeType]]
 
 
 def build_bencode_node[T: BencodeType](
@@ -67,7 +65,7 @@ def build_bencode_node[T: BencodeType](
 @overload
 def get[T: BencodeType](
     type_dest: type[T],
-    data: BencodeNode[BencodeDict],
+    data: BencodeNode[dict[bytes, BencodeType]],
     key: bytes,
     *,
     default: T | None = None,
@@ -75,14 +73,14 @@ def get[T: BencodeType](
 @overload
 def get[T: BencodeType](
     type_dest: type[T],
-    data: BencodeNode[BencodeDict],
+    data: BencodeNode[dict[bytes, BencodeType]],
     key: bytes,
     *,
     optional: Literal[True],
 ) -> BencodeNode[T] | None: ...
 def get[T: BencodeType](
     type_dest: type[T],
-    data: BencodeNode[BencodeDict],
+    data: BencodeNode[dict[bytes, BencodeType]],
     key: bytes,
     *,
     default: T | None = None,
@@ -111,7 +109,7 @@ def check_for_qbt_sqlite_resume_db(qbt_bt_backup_dir: str) -> None:
         raise QbtUsesSqliteForResumeError()
 
 
-def get_data(root_path: str, file_path: str) -> BencodeDictNode:
+def get_data(root_path: str, file_path: str) -> BencodeDict:
     with open(file_path, "rb") as f:
         try:
             decoded = bdecode(f.read())
@@ -122,12 +120,12 @@ def get_data(root_path: str, file_path: str) -> BencodeDictNode:
 
 # FIXME BEP0003 says that clients must not perform a decode-encode
 # roundtrip on invalid data. this is exactly what this does.
-def calc_info_hash(parsed_tor: BencodeDictNode) -> str:
+def calc_info_hash(parsed_tor: BencodeDict) -> str:
     info, _ = get(dict[bytes, BencodeType], parsed_tor, b"info")
     return hashlib.sha1(bencode(info)).hexdigest()
 
 
-def transmission_get_speed_limit(resume_data: BencodeDictNode, key: bytes) -> int:
+def transmission_get_speed_limit(resume_data: BencodeDict, key: bytes) -> int:
     speed_limit_obj = get(dict[bytes, BencodeType], resume_data, key)
     use_speed_limit, _ = get(int, speed_limit_obj, b"use-speed-limit")
     if use_speed_limit != 0:
@@ -136,7 +134,7 @@ def transmission_get_speed_limit(resume_data: BencodeDictNode, key: bytes) -> in
     return -1
 
 
-def transmission_get_file_prorities(resume_data: BencodeDictNode) -> Generator[int]:
+def transmission_get_file_prorities(resume_data: BencodeDict) -> Generator[int]:
     priority_node = get(list[BencodeType], resume_data, b"priority", optional=True)
     dnd_node = get(list[BencodeType], resume_data, b"dnd", optional=True)
 
@@ -179,7 +177,7 @@ def peers_convert_from_raw_bytes(src: bytes, addr_size: int) -> bytes:
     return bytes(rv)
 
 
-def peers_convert_from_bencoded(src: BencodeList, key: bytes) -> bytes:
+def peers_convert_from_bencoded(src: list[BencodeType], key: bytes) -> bytes:
     # used since Transmission commit 1054ba4 (earliest release - 4.1.0)
     rv = bytearray()
     for i, d in enumerate(src):
@@ -191,7 +189,7 @@ def peers_convert_from_bencoded(src: BencodeList, key: bytes) -> bytes:
 
 
 def transmission_get_peers(
-    resume_data: BencodeDictNode, addr_size: int, key: bytes
+    resume_data: BencodeDict, addr_size: int, key: bytes
 ) -> bytes:
     src = resume_data.value.get(key)
     if src is None:
@@ -206,7 +204,7 @@ def transmission_get_peers(
     raise ConversionError(f"{key} is not a list or bytes")
 
 
-def transmission_get_limit(tr_resume: BencodeDictNode, limit_kind: str) -> int:
+def transmission_get_limit(tr_resume: BencodeDict, limit_kind: str) -> int:
     limit_key = f"{limit_kind}-limit".encode()
     limit_obj = get(dict[bytes, BencodeType], tr_resume, limit_key)
 
@@ -256,9 +254,7 @@ def get_last_piece_mask_for_block_checking(torrent_size: int, piece_size: int) -
     return piece_mask
 
 
-def transmission_get_pieces(
-    parsed_tor: BencodeDictNode, tr_resume: BencodeDictNode
-) -> bytes:
+def transmission_get_pieces(parsed_tor: BencodeDict, tr_resume: BencodeDict) -> bytes:
     info = get(dict[bytes, BencodeType], parsed_tor, b"info")
     torrent_size, _ = get(int, info, b"length")
     piece_size, _ = get(int, info, b"piece length")
@@ -319,8 +315,8 @@ def transmission_get_pieces(
 
 
 def map_resume_to_qbt(
-    info_hash: str, parsed_tor: BencodeDictNode, resume_data: BencodeDictNode
-) -> BencodeDict:
+    info_hash: str, parsed_tor: BencodeDict, resume_data: BencodeDict
+) -> dict[bytes, BencodeType]:
     downloading_time_seconds, _ = get(int, resume_data, b"downloading-time-seconds")
     seeding_time_seconds, _ = get(int, resume_data, b"seeding-time-second")
     name, _ = get(bytes, resume_data, b"name")
@@ -407,8 +403,8 @@ class TransmissionQbtImporter:
         self,
         source_tor_abs_path: str,
         info_hash: str,
-        parsed_tor: BencodeDictNode,
-        resume_data: BencodeDictNode,
+        parsed_tor: BencodeDict,
+        resume_data: BencodeDict,
     ) -> None:
         qbt_resume_data = map_resume_to_qbt(info_hash, parsed_tor, resume_data)
         qbt_resume_path = os.path.join(self.target_dir, info_hash + ".fastresume")

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -50,7 +50,7 @@ type BencodeDict = BencodeNode[dict[bytes, BencodeType]]
 
 
 def build_node[T: BencodeType](
-    type: type[T], value: BencodeType, path: str
+    value: BencodeType, type: type[T], path: str
 ) -> BencodeNode[T]:
     # origin is the parent class for generics (e.g. list for list[int])
     # origin is none for non-generics
@@ -62,15 +62,24 @@ def build_node[T: BencodeType](
     return BencodeNode(cast(T, value), path)
 
 
+def get_children[T: BencodeType](
+    node: BencodeNode[list[BencodeType]], child_type: type[T]
+):
+    parent, parent_path = node
+    for index, child in enumerate(parent):
+        child_path = f"{parent_path}[{index}]"
+        yield build_node(child, child_type, child_path)
+
+
 @overload
 def get_child[T: BencodeType](
-    parent: BencodeNode[dict[bytes, BencodeType]],
+    node: BencodeNode[dict[bytes, BencodeType]],
     child_name: bytes,
     child_type: type[T],
 ) -> BencodeNode[T]: ...
 @overload
 def get_child[T: BencodeType](
-    parent: BencodeNode[dict[bytes, BencodeType]],
+    node: BencodeNode[dict[bytes, BencodeType]],
     child_name: bytes,
     child_type: type[T],
     *,
@@ -78,27 +87,28 @@ def get_child[T: BencodeType](
 ) -> BencodeNode[T]: ...
 @overload
 def get_child[T: BencodeType](
-    parent: BencodeNode[dict[bytes, BencodeType]],
+    node: BencodeNode[dict[bytes, BencodeType]],
     child_name: bytes,
     child_type: type[T],
     *,
     optional: Literal[True],
 ) -> BencodeNode[T] | None: ...
 def get_child[T: BencodeType](
-    parent: BencodeNode[dict[bytes, BencodeType]],
+    node: BencodeNode[dict[bytes, BencodeType]],
     child_name: bytes,
     child_type: type[T],
     *,
     default: T | None = None,
     optional: bool = False,
 ) -> BencodeNode[T] | None:
-    child_value = parent.value.get(child_name, default)
-    child_path = f"{parent.path}.{child_name.decode()}"
-    if child_value is None:
+    parent, parent_path = node
+    child = parent.get(child_name, default)
+    child_path = f"{parent_path}.{child_name.decode()}"
+    if child is None:
         if optional:
             return None
         raise ConversionError(f"{child_path} is missing")
-    return build_node(child_type, child_value, child_path)
+    return build_node(child, child_type, child_path)
 
 
 def bencode(data: BencodeType) -> bytes:
@@ -115,13 +125,13 @@ def check_for_qbt_sqlite_resume_db(qbt_bt_backup_dir: str) -> None:
         raise QbtUsesSqliteForResumeError()
 
 
-def read_bencoded(file_path: str, node_path: str) -> BencodeDict:
+def read_bencoded(file_path: str, root_path: str) -> BencodeDict:
     with open(file_path, "rb") as f:
         try:
-            decoded = bdecode(f.read())
+            root = bdecode(f.read())
         except (ValueError, bencodepy.BencodeDecodeError) as e:
             raise ReadBencodedError(file_path) from e
-    return build_node(dict[bytes, BencodeType], decoded, node_path)
+    return build_node(root, dict[bytes, BencodeType], root_path)
 
 
 # FIXME BEP0003 says that clients must not perform a decode-encode
@@ -183,28 +193,25 @@ def peers_convert_from_raw_bytes(src: bytes, addr_size: int) -> bytes:
     return bytes(rv)
 
 
-def peers_convert_from_bencoded(src: list[BencodeType], key: bytes) -> bytes:
+def peers_convert_from_bencoded(resume: BencodeDict, key: bytes) -> bytes:
     # used since Transmission commit 1054ba4 (earliest release - 4.1.0)
+
+    peers = get_child(resume, key, list[BencodeType])
     rv = bytearray()
-    for i, x in enumerate(src):
-        d = build_node(dict[bytes, BencodeType], x, f"{key}[{i}]")
-        socket_address, _ = get_child(d, b"socket_address", bytes)
-        rv += socket_address
+    for d in get_children(peers, dict[bytes, BencodeType]):
+        rv += get_child(d, b"socket_address", bytes).value
     return bytes(rv)
 
 
-def transmission_get_peers(resume: BencodeDict, addr_size: int, key: bytes) -> bytes:
+def transmission_get_peers(resume: BencodeDict, key: bytes, addr_size: int) -> bytes:
     src = resume.value.get(key)
     if src is None:
         return b""
 
-    if isinstance(src, list):
-        return peers_convert_from_bencoded(src, key)
-
     if isinstance(src, bytes):
         return peers_convert_from_raw_bytes(src, addr_size)
 
-    raise ConversionError(f"{key} is not a list or bytes")
+    return peers_convert_from_bencoded(resume, key)
 
 
 def transmission_get_limit(resume: BencodeDict, limit_kind: str) -> int:
@@ -320,11 +327,11 @@ def transmission_get_pieces(torrent: BencodeDict, resume: BencodeDict) -> bytes:
     info = get_child(torrent, b"info", dict[bytes, BencodeType])
     torrent_size_node = get_child(info, b"length", int, optional=True)
     if torrent_size_node is None:
-        files, files_path = get_child(info, b"files", list[BencodeType])
-        torrent_size = 0
-        for i, f in enumerate(files):
-            file_dict = build_node(dict[bytes, BencodeType], f, f"{files_path}[{i}]")
-            torrent_size += get_child(file_dict, b"length", int).value
+        files = get_child(info, b"files", list[BencodeType])
+        torrent_size = sum(
+            get_child(file, b"length", int).value
+            for file in get_children(files, dict[bytes, BencodeType])
+        )
     else:
         torrent_size, _ = torrent_size_node
     piece_size, _ = get_child(info, b"piece length", int)
@@ -369,19 +376,56 @@ def transmission_get_pieces(torrent: BencodeDict, resume: BencodeDict) -> bytes:
     return bytes(qb_pieces)
 
 
+def transmission_get_files(
+    torrent_info: BencodeDict, resume: BencodeDict
+) -> None | list[BencodeType]:
+    resume_files_node = get_child(resume, b"files", list[BencodeType], optional=True)
+    if resume_files_node is None:
+        return None
+
+    torrent_name, _ = get_child(torrent_info, b"name", bytes)
+
+    actual_files: list[BencodeType] = [
+        f.value for f in get_children(resume_files_node, bytes)
+    ]
+
+    torrent_files_node = get_child(
+        torrent_info, b"files", list[BencodeType], optional=True
+    )
+    if torrent_files_node is None:
+        # Single-file torrent
+        expected_files = [torrent_name]
+    else:
+        # Multi-file torrent
+        torrent_files = torrent_files_node
+        expected_files = list[bytes]()
+        for torrent_file in get_children(torrent_files, dict[bytes, BencodeType]):
+            paths = get_child(torrent_file, b"path", list[BencodeType])
+            expected_files.append(
+                torrent_name
+                + b"/".join(path.value for path in get_children(paths, bytes))
+            )
+
+    if actual_files == expected_files:
+        # mapped_files is not present if no file is renamed
+        return None
+
+    return actual_files
+
+
 def map_resume_to_qbt(
     info_hash: str, torrent: BencodeDict, resume: BencodeDict
 ) -> dict[bytes, BencodeType]:
     downloading_time_seconds, _ = get_child(resume, b"downloading-time-seconds", int)
     seeding_time_seconds, _ = get_child(resume, b"seeding-time-seconds", int)
-    name, _ = get_child(resume, b"name", bytes)
+    resume_name, _ = get_child(resume, b"name", bytes)
     paused, _ = get_child(resume, b"paused", int)
 
     qbt_resume_data: BencodeType = {
         b"file-format": b"libtorrent resume file",
         b"file-version": 1,
         b"info-hash": binascii.unhexlify(info_hash),
-        b"name": name,
+        b"name": resume_name,
         b"total_uploaded": get_child(resume, b"uploaded", int).value,
         b"total_downloaded": get_child(resume, b"downloaded", int).value,
         b"added_time": get_child(resume, b"added-date", int).value,
@@ -400,34 +444,40 @@ def map_resume_to_qbt(
             resume, b"sequentialDownload", int, default=0
         ).value,
         b"file_priority": list(transmission_get_file_priorities(resume)),
-        b"qBt-name": name,
         b"qBt-ratioLimit": transmission_get_limit(resume, "ratio"),
         b"qBt-inactiveSeedingTimeLimit": int(transmission_get_limit(resume, "idle")),
         b"qBt-savePath": get_child(resume, b"destination", bytes).value,
         b"pieces": transmission_get_pieces(torrent, resume),
     }
 
-    info = get_child(torrent, b"info", dict[bytes, BencodeType])
-    private, _ = get_child(info, b"private", int, default=0)
+    torrent_info = get_child(torrent, b"info", dict[bytes, BencodeType])
+
+    private, _ = get_child(torrent_info, b"private", int, default=0)
     if not private:
-        qbt_resume_data[b"peers"] = transmission_get_peers(resume, 4, b"peers2")
-        qbt_resume_data[b"peers6"] = transmission_get_peers(resume, 16, b"peers2-6")
+        qbt_resume_data[b"peers"] = transmission_get_peers(resume, b"peers2", 4)
+        qbt_resume_data[b"peers6"] = transmission_get_peers(resume, b"peers2-6", 16)
 
     group = get_child(resume, b"group", bytes, optional=True)
     if group is not None:
-        qbt_resume_data[b"qBt-category"] = group.value
+        qbt_resume_data[b"qBt-category"], _ = group
 
     labels = get_child(resume, b"labels", list[BencodeType], optional=True)
     if labels is not None:
-        qbt_resume_data[b"qBt-tags"] = labels.value
+        qbt_resume_data[b"qBt-tags"], _ = labels
 
-    files = get_child(resume, b"files", list[BencodeType], optional=True)
+    # qBt-name is present but empty when the torrent is not renamed
+    if resume_name == get_child(torrent_info, b"name", bytes):
+        qbt_resume_data[b"qBt-name"] = b""
+    else:
+        qbt_resume_data[b"qBt-name"] = resume_name
+
+    files = transmission_get_files(torrent_info, resume)
     if files is not None:
-        qbt_resume_data[b"mapped_files"] = files.value
+        qbt_resume_data[b"mapped_files"] = files
 
     incomplete_dir = get_child(resume, b"incomplete_dir", bytes, optional=True)
     if incomplete_dir is not None:
-        qbt_resume_data[b"qBt-downloadPath"] = incomplete_dir.value
+        qbt_resume_data[b"qBt-downloadPath"], _ = incomplete_dir
 
     if paused == 1:
         qbt_resume_data[b"auto_managed"] = 0

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -134,7 +134,7 @@ def transmission_get_speed_limit(resume: BencodeDict, key: bytes) -> int:
     return -1
 
 
-def transmission_get_file_prorities(resume: BencodeDict) -> Generator[int]:
+def transmission_get_file_priorities(resume: BencodeDict) -> Generator[int]:
     priority_node = get_child(resume, b"priority", list[BencodeType], optional=True)
     dnd_node = get_child(resume, b"dnd", list[BencodeType], optional=True)
 
@@ -220,98 +220,148 @@ def transmission_get_limit(resume: BencodeDict, limit_kind: str) -> int:
 
 
 BLOCK_SIZE = 1 << 14  # 16KiB, standard across torrents
+FIRST_BYTE_MASK_BY_BIT_ORDER = {i: 0xFF >> i for i in range(0, 8)}
+LAST_BYTE_MASK_BY_BIT_ORDER = {i: 0xFF << 7 - i & 0xFF for i in range(0, 8)}
 
 
-def get_last_piece_mask_for_block_checking(torrent_size: int, piece_size: int) -> bytes:
-    # We use masks to determine if torrent pieces are on disk, by extracting progress info
-    # from the Transmission resume for the pieces and comparing them to the mask.
-    # This method creates the mask for the last piece of the torrent, which is not as trivial
-    # as for the other pieces (where the mask is just 1s)
-    # This method is used by transmission_get_pieces
+def is_piece_complete(
+    tr_blocks: bytes, piece_index: int, blocks_per_piece: int, num_blocks: int
+):
+    # The blocks data the in Transmission resume (tr_blocks) is a bitmask in the form of a bytes object (an immutable array of bytes, aka a
+    # binary string).
+    # Each byte represents 8 blocks: each bit in that byte represents a single block, i.e. a 16KiB chunk of torrent data.
+    # Each bit is equal to 1 if the block is on disk, 0 if not.
+    #
+    # The pieces data in the qBittorrent/libtorrent resume (qb_pieces) is also a bytes object but not a bitmask: each byte represent a piece,
+    # and is equal to 0x01 if the piece is on disk, 0x00 if not (only one of the 8 bits is used in each byte, the first 7 bits are always 0).
+    #
+    # Blocks are the atomic amount of data used for storage. Pieces are used in the hash calculation (in Bittorrent v1), the protocol, and in
+    # the resume files, such as qb_pieces here.
+    # There is an additional field (unfinished) in the qBittorrent resume to store block info for incomplete pieces, but this field is ignored
+    # here, see README.md.
+    #
+    # The piece size is a multiple of the block size, but not always a multiple of 8*16KiB (the data chunk represented by a tr_blocks byte).
+    # Which means that a tr_blocks byte might represent more than one qb_pieces byte, and vice versa; it also means that the first block of each
+    # piece will not necessarily be aligned with the leftmost bit of a tr_blocks byte.
+    #
+    # So to understand which pieces are fully on disk (which is what we need to build qb_pieces), we need to extract piece_blocks for each piece
+    # in tr_blocks, and check if they are all 1.
+    # We start by finding what tr_block byte the piece starts and ends with. It might start midway through a byte (i.e. not the leftmost bit of
+    # the start byte) and likewise it might end midway through a byte (not the rightmost bit of the end byte). For this reason the first and last
+    # byte are checked using a bitwise masking operation, with a precalculated dict of masks indexed with the order of the first and last bit.
+    # For instance, if the start bit order is 3, then the mask is 00011111 (0x1f). We mask the byte coming from tr_blocks against this
+    # i.e. tr_blocks[piece_start] & 0x1f == 0x1f. The masks for the end bit order are reversed i.e. if the bit order is 3, the mask is
+    # 11110000 (0xf0) so we will check if tr_blocks[piece_end] & 0xf0 == 0xf0.
+    # All the tr_blocks bytes between the first and the last are fully part of the piece, so if the piece is complete the block bytes are all
+    # 0xff. No need to mask for these, we can just compare them all to 0xff.
+    #
+    # There is a special case when a piece is fully contained within a block byte (which only happens when the piece length is <= 8*16KiB).
+    # In this case there is only one block byte to check and we need to mask it against both the start and end mask.
+    #
+    # We also need to take in account that the total number of blocks might not align with the end of a piece, i.e. the last piece can be smaller.
+    #
+    # In another special case, tr_blocks might contain fewer bytes than expected, because Transmission does not write the end of tr_blocks when the
+    # end of the torrent is not on disk (it will only write up to the last block that is on disk). For that reason when retrieving a piece we might
+    # get fewer bytes than expected. In that case we need to return False since it means that the piece is not on disk.
+    #
+    # Finally, Transmission sets the whole tr_blocks to b"all" for complete torrents and b"none" for empty torrents, so these special cases must
+    # be dealt with separately.
 
-    # Size of the last piece
-    # Note that in the special case where the torrent size is a multiple of the piece size,
-    # the last piece has the same size as all the other pieces
-    last_piece_size = torrent_size % piece_size or piece_size
+    # Indexes of the first block of the piece
+    # In total blocks
+    piece_start_in_overall_blocks = piece_index * blocks_per_piece
+    # In tr_blocks
+    piece_start_in_block_bytes = piece_start_in_overall_blocks // 8
+    # in the specific tr_blocks byte
+    piece_start_bit_order = piece_start_in_overall_blocks % 8
 
-    # Number of blocks in the last piece
-    # Ceiling integer division
-    blocks_in_last_piece = -(-last_piece_size // BLOCK_SIZE)
+    # Indexes of the last block of the piece
+    # In total blocks
+    piece_end_in_overall_blocks = (
+        min(piece_start_in_overall_blocks + blocks_per_piece, num_blocks) - 1
+    )
+    # In tr_blocks
+    piece_end_in_block_bytes = piece_end_in_overall_blocks // 8
+    # in the specific tr_blocks byte
+    piece_end_bit_order = piece_end_in_overall_blocks % 8
 
-    # Get the start of the mask, made of 1s in groups of 8
-    mask_full_bytes = blocks_in_last_piece // 8
-    piece_mask = b"\xff" * mask_full_bytes
-
-    # Append last byte of the mask: 1s followed by 0s
-    mask_extra_bits = blocks_in_last_piece % 8
-    if mask_extra_bits:
-        # Create a byte made of n 1s followed by (8-n) 0s
-        piece_mask += bytes([0xFF << 8 - mask_extra_bits & 0xFF])
-
-    return piece_mask
+    num_piece_bytes = piece_end_in_block_bytes - piece_start_in_block_bytes + 1
+    piece_bytes = tr_blocks[
+        piece_start_in_block_bytes : piece_start_in_block_bytes + num_piece_bytes
+    ]
+    if len(piece_bytes) < num_piece_bytes:
+        # tr_blocks is shorter than expected, meaning the piece is not complete
+        return False
+    first_byte_mask = FIRST_BYTE_MASK_BY_BIT_ORDER[piece_start_bit_order]
+    last_byte_mask = LAST_BYTE_MASK_BY_BIT_ORDER[piece_end_bit_order]
+    if num_piece_bytes == 1:
+        byte_mask = first_byte_mask & last_byte_mask
+        return piece_bytes[0] & byte_mask == byte_mask
+    if piece_bytes[0] & first_byte_mask != first_byte_mask:
+        return False
+    if piece_bytes[-1] & last_byte_mask != last_byte_mask:
+        return False
+    return piece_bytes[1:-1] == b"\xff" * (num_piece_bytes - 2)
 
 
 def transmission_get_pieces(torrent: BencodeDict, resume: BencodeDict) -> bytes:
     info = get_child(torrent, b"info", dict[bytes, BencodeType])
-    torrent_size, _ = get_child(info, b"length", int)
+    torrent_size_node = get_child(info, b"length", int, optional=True)
+    if torrent_size_node is None:
+        files, files_path = get_child(info, b"files", list[BencodeType])
+        torrent_size = 0
+        for i, f in enumerate(files):
+            file_dict = build_node(dict[bytes, BencodeType], f, f"{files_path}[{i}]")
+            torrent_size += get_child(file_dict, b"length", int).value
+    else:
+        torrent_size, _ = torrent_size_node
     piece_size, _ = get_child(info, b"piece length", int)
 
-    # Sanity check the piece length
-    # Only accept piece size in powers of 2
-    if piece_size & -piece_size != piece_size:  # This is only true for powers of 2
-        raise ConversionError(f"Piece size {piece_size} is not a power of 2")
-    # The progress.blocks bytes in the Transmission resume contain 1 bit per data block (where bit=1 means the block is on disk)
-    # So each byte in progress.blocks represents 8 blocks
-    # The pieces bytes in the qBittorrent resume contains a full byte per piece, where 0x01 means the piece is on disk
-    # The algorithm in this method determines if a piece is complete by extracting progress.blocks bytes in groups of n
-    # (where n=piece_size//BLOCK_SIZE//8), and checking that they are all 0xff
-    # For this to work without having to do bitwise operations, the piece size must be at least 8x the block size
-    # The block size is 16KiB so the minimum piece size is 128KiB
-    min_piece_size = 8 * BLOCK_SIZE
-    if piece_size < min_piece_size:
+    # Sanity check the piece size
+    if piece_size % BLOCK_SIZE > 0:
         raise ConversionError(
-            f"Piece size {naturalsize(min_piece_size, binary=True)} is lower than {naturalsize(min_piece_size, binary=True)}, aborting"
+            f"Piece size {piece_size} is not a multiple of {naturalsize(BLOCK_SIZE, binary=True)}, aborting"
         )
+    
+    blocks_per_piece = piece_size // BLOCK_SIZE
+    # ceiling integer division
+    num_pieces = -(-torrent_size // piece_size)
+    num_blocks = -(-torrent_size // BLOCK_SIZE)
 
     progress = get_child(resume, b"progress", dict[bytes, BencodeType])
-    blocks, _ = get_child(progress, b"blocks", bytes)
+    tr_blocks, _ = get_child(progress, b"blocks", bytes)
+
+    # Shorthand for complete torrents
+    if tr_blocks == b"all":
+        return b"\x01" * num_pieces
+    # Shorthand for empty torrents
+    if tr_blocks == b"none":
+        return b"\x00" * num_pieces
 
     # Sanity check the block bytes length
     # ceiling integer division
-    expected_num_blocks = -(-torrent_size // BLOCK_SIZE // 8)
-    if len(blocks) != expected_num_blocks:
+    expected_block_bytes = -(-num_blocks // 8)
+    if len(tr_blocks) > expected_block_bytes:
         raise ConversionError(
-            f"resume block length was expected to be {expected_num_blocks} but was {len(blocks)}"
+            f"the resume block length was expected to be {expected_block_bytes} but was {len(tr_blocks)}"
+        )
+    if len(tr_blocks) < expected_block_bytes:
+        # This happens on incomplete torrents, specifically when the last blocks are not on disk
+        # In these cases Transmission will not write the full blocks to the resume
+        # We can skip the check on all missing pieces
+        logging.warning(
+            f"incomplete torrent: the Transmission resume block has {len(tr_blocks)} bytes instead of {expected_block_bytes}, the qBittorrent pieces will be padded to size"
         )
 
-    # ceiling integer division
-    num_pieces = -(-torrent_size // piece_size)
-
     # Initialise the return object with 0s
-    qbit_pieces = bytearray(num_pieces)
-
-    blocks_per_piece = piece_size // BLOCK_SIZE
-    block_bytes_per_piece = blocks_per_piece // 8
-
-    # What a full piece looks like in progress.blocks
-    full_piece_mask = b"\xff" * block_bytes_per_piece
+    qb_pieces = bytearray(num_pieces)
 
     # Go through progress.blocks, grouping them into pieces
     for piece_index in range(num_pieces):
-        piece_start = piece_index * block_bytes_per_piece
-        piece_blocks = blocks[piece_start : piece_start + block_bytes_per_piece]
+        if is_piece_complete(tr_blocks, piece_index, blocks_per_piece, num_blocks):
+            qb_pieces[piece_index] = 0x01
 
-        # The last piece is special: if it is not exactly 128KiB then progress.blocks does not end with 0xff even when complete
-        # So we need to calculate the expected mask, then compare it to the last byte(s) of the blocks object
-        if piece_index == num_pieces - 1:
-            full_piece_mask = get_last_piece_mask_for_block_checking(
-                torrent_size, piece_size
-            )
-
-        if piece_blocks == full_piece_mask:
-            qbit_pieces[piece_index] = 1
-
-    return bytes(qbit_pieces)
+    return bytes(qb_pieces)
 
 
 def map_resume_to_qbt(
@@ -344,7 +394,7 @@ def map_resume_to_qbt(
         b"sequential_download": get_child(
             resume, b"sequentialDownload", int, default=0
         ).value,
-        b"file_priority": list(transmission_get_file_prorities(resume)),
+        b"file_priority": list(transmission_get_file_priorities(resume)),
         b"peers": transmission_get_peers(resume, 4, b"peers2"),
         b"peers6": transmission_get_peers(resume, 16, b"peers2-6"),
         b"qBt-name": name,
@@ -382,6 +432,7 @@ class Args:
     transmission_config_dir: str
     predicate: str | None
     dry_run: bool
+    log_level: int
 
 
 class TransmissionQbtImporter:
@@ -497,18 +548,17 @@ class TransmissionQbtImporter:
 
                 except ConversionError as e:
                     logging.warning(
-                        f"Error while converting resume data for {torf} : {str(e)}"
+                        f"Error while converting resume data for {torf} : {e}"
                     )
                 except OSError as e:
                     logging.warning(
                         f"Failed to read {e.filename} ({e.strerror}), skipping"
                     )
                 except ReadBencodedError as e:
-                    logging.warning(f"Failed to decode {str(e)}, skipping")
+                    logging.warning(f"Failed to decode {e}, skipping")
 
 
 def main() -> int:
-    logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(message)s")
     parser = argparse.ArgumentParser(
         prog="transmission2qbt",
         description="Imports all your torrents from Transmission to qBittorrent while trying to preserve as much metadata as possible",
@@ -533,8 +583,17 @@ def main() -> int:
         action="store_true",
         help="Optional flag to not write any data to disk",
     )
+    parser.add_argument(
+        "--log-level",
+        "-l",
+        type=int,
+        default=logging.INFO,
+        help="Optional flag to set log level, see https://docs.python.org/3/library/logging.html#logging-levels",
+    )
 
     args = cast(Args, parser.parse_args())
+    logging.basicConfig(level=args.log_level, format="%(levelname)s: %(message)s")
+
     try:
         TransmissionQbtImporter(args).scan()
     except QbtUsesSqliteForResumeError:

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -134,7 +134,7 @@ class BencodeDict:
         return wrap(t, child_node, child_path)
 
     def encode(self) -> bytes:
-        """Bencodes the wrapped data and returns the resulting string."""
+        """Unwraps the data and returns it as a bencoded string."""
         return encode(self._node)
 
     @staticmethod

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from typing import Literal, cast, overload
+from collections.abc import Generator, Iterator
 import sys
 import os
 import argparse
@@ -19,7 +20,7 @@ class ConversionError(RuntimeError):
     pass
 
 
-def rm_f(path: str):
+def rm_f(path: str) -> None:
     try:
         os.remove(path)
     except (FileNotFoundError, OSError):
@@ -39,10 +40,43 @@ type BencodeDict = dict[bytes, "BencodeType"]
 type BencodeType = bytes | int | BencodeList | BencodeDict
 
 
-@dataclass(frozen=True)
-class BencodeData:
-    path: str
-    data: BencodeDict
+class BencodeListWrapper[T: bytes | int](Iterator[T]):
+    def __init__(self, item_type: type[T], path: str, data: BencodeList) -> None:
+        self._item_type = item_type
+        self._path = path
+        self._data = data
+        self._iter = iter(self._data)
+        self._index = -1
+
+    def unwrap(self) -> BencodeList:
+        return self._data
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def __iter__(self) -> Iterator[T]:
+        return self
+
+    def __next__(self) -> T:
+        self._index += 1
+
+        try:
+            next_item = next(self._iter)
+        except StopIteration:
+            raise StopIteration
+
+        if not isinstance(next_item, self._item_type):
+            raise ConversionError(f"{self._path}[{self._index}] is not bytes")
+        return next_item
+
+
+class BencodeDictWrapper:
+    def __init__(self, path: str, data: BencodeDict) -> None:
+        self._path: str
+        self._data: BencodeDict
+
+    def unwrap(self) -> BencodeDict:
+        return self._data
 
     @overload
     def get[T: bytes | int](self, type: type[T], key: bytes) -> T: ...
@@ -60,55 +94,61 @@ class BencodeData:
         optional: bool = False,
         default: T | None = None,
     ) -> T | None:
-        result = self.data.get(key)
+        result = self._data.get(key)
         if result is None:
             if optional or default is not None:
                 return default
-            raise ConversionError(f"{self.path}.{key.decode()} missing")
+            raise ConversionError(f"{self._path}.{key.decode()} missing")
 
         if not isinstance(result, type):
-            raise ConversionError(f"{self.path}.{key.decode()} is not {type}")
+            raise ConversionError(f"{self._path}.{key.decode()} is not {type}")
 
         return result
 
     @overload
-    def get_list(self, key: bytes) -> BencodeList: ...
+    def get_list[T: bytes | int](
+        self, item_type: type[T], key: bytes
+    ) -> BencodeListWrapper[T]: ...
     @overload
-    def get_list(
-        self, key: bytes, *, optional: Literal[True]
-    ) -> BencodeList | None: ...
-    def get_list(self, key: bytes, *, optional: bool = False) -> BencodeList | None:
-        result = self.data.get(key)
-        if result is None:
+    def get_list[T: bytes | int](
+        self, item_type: type[T], key: bytes, *, optional: Literal[True]
+    ) -> BencodeListWrapper[T] | None: ...
+    def get_list[T: bytes | int](
+        self, item_type: type[T], key: bytes, *, optional: bool = False
+    ) -> BencodeListWrapper[T] | None:
+        data = self._data.get(key)
+        if data is None:
             if optional:
                 return None
-            raise ConversionError(f"{self.path}.{key.decode()} missing")
+            raise ConversionError(f"{self._path}.{key.decode()} is missing")
 
-        if not isinstance(result, list):
-            raise ConversionError(f"{self.path}.{key.decode()} is not list")
+        if not isinstance(data, list):
+            raise ConversionError(f"{self._path}.{key.decode()} is not a list")
 
-        return result
+        return BencodeListWrapper(item_type, f"{self._path}.{key.decode()}", data)
 
     @overload
-    def get_dict(self, key: bytes) -> "BencodeData": ...
+    def get_dict(self, key: bytes) -> "BencodeDictWrapper": ...
     @overload
     def get_dict(
         self, key: bytes, *, optional: Literal[True]
-    ) -> "BencodeData | None": ...
-    def get_dict(self, key: bytes, *, optional: bool = False) -> "BencodeData | None":
-        result = self.data.get(key)
+    ) -> "BencodeDictWrapper | None": ...
+    def get_dict(
+        self, key: bytes, *, optional: bool = False
+    ) -> "BencodeDictWrapper | None":
+        result = self._data.get(key)
         if result is None:
             if optional:
                 return None
-            raise ConversionError(f"{self.path}.{key.decode()} missing")
+            raise ConversionError(f"{self._path}.{key.decode()} missing")
 
         if not isinstance(result, dict):
-            raise ConversionError(f"{self.path}.{key.decode()} is not dict")
+            raise ConversionError(f"{self._path}.{key.decode()} is not a dict")
 
-        return BencodeData(f"{self.path}.{key.decode()}", result)
+        return BencodeDictWrapper(f"{self._path}.{key.decode()}", result)
 
 
-def bencode(data: BencodeType):
+def bencode(data: BencodeType) -> bytes:
     return bencodepy.bencode(data)  # type: ignore
 
 
@@ -116,13 +156,13 @@ def bdecode(data: bytes) -> BencodeType:
     return bencodepy.bdecode(data)  # type: ignore
 
 
-def check_for_qbt_sqlite_resume_db(qbt_bt_backup_dir: str):
+def check_for_qbt_sqlite_resume_db(qbt_bt_backup_dir: str) -> None:
     torrents_db_path = os.path.join(qbt_bt_backup_dir, "..", "torrents.db")
     if os.path.exists(torrents_db_path):
         raise QbtUsesSqliteForResumeError()
 
 
-def get_data(root: str, path: str):
+def get_data(root: str, path: str) -> BencodeDictWrapper:
     with open(path, "rb") as f:
         try:
             decoded = bdecode(f.read())
@@ -130,17 +170,17 @@ def get_data(root: str, path: str):
             raise ReadBencodedError(path) from e
     if not isinstance(decoded, dict):
         raise ConversionError(f"{root} is not a dict")
-    return BencodeData(root, decoded)
+    return BencodeDictWrapper(root, decoded)
 
 
 # FIXME BEP0003 says that clients must not perform a decode-encode
 # roundtrip on invalid data. this is exactly what this does.
-def calc_info_hash(parsed_tor: BencodeData):
+def calc_info_hash(parsed_tor: BencodeDictWrapper) -> str:
     info = parsed_tor.get_dict(b"info")
-    return hashlib.sha1(bencode(info.data))
+    return hashlib.sha1(bencode(info.unwrap())).hexdigest()
 
 
-def transmission_get_speed_limit(resume_data: BencodeData, key: bytes):
+def transmission_get_speed_limit(resume_data: BencodeDictWrapper, key: bytes) -> int:
     speed_limit_obj = resume_data.get_dict(key)
     if speed_limit_obj.get(int, b"use-speed-limit") != 0:
         return speed_limit_obj.get(int, b"speed-Bps")
@@ -148,9 +188,9 @@ def transmission_get_speed_limit(resume_data: BencodeData, key: bytes):
     return -1
 
 
-def transmission_get_file_prorities(resume_data: BencodeData):
-    priority = resume_data.get_list(b"priority", optional=True)
-    dnd = resume_data.get_list(b"dnd", optional=True)
+def transmission_get_file_prorities(resume_data: BencodeDictWrapper) -> Generator[int]:
+    priority = resume_data.get_list(int, b"priority", optional=True)
+    dnd = resume_data.get_list(int, b"dnd", optional=True)
 
     # Return empty list if priority data is not available
     if priority is None or dnd is None:
@@ -162,10 +202,6 @@ def transmission_get_file_prorities(resume_data: BencodeData):
         )
 
     for i, (p, d) in enumerate(zip(priority, dnd, strict=True)):
-        if not isinstance(p, int):
-            raise ConversionError(f"priority[{i}] is not an int")
-        if not isinstance(d, int):
-            raise ConversionError(f"dnd[{i}] is not an int")
         if d == 1:
             yield 0  # libtorrent::dont_download
         else:
@@ -180,7 +216,7 @@ def transmission_get_file_prorities(resume_data: BencodeData):
                     raise ConversionError(f"Unknown priority[{i}]: {p}")
 
 
-def peers_convert_from_raw_bytes(src: bytes, addr_size: int):
+def peers_convert_from_raw_bytes(src: bytes, addr_size: int) -> bytes:
     rv = bytearray()
     i = 0
     while i < len(src):
@@ -193,7 +229,7 @@ def peers_convert_from_raw_bytes(src: bytes, addr_size: int):
     return bytes(rv)
 
 
-def peers_convert_from_bencoded(src: BencodeList, key: bytes):
+def peers_convert_from_bencoded(src: BencodeList, key: bytes) -> bytes:
     # used since Transmission commit 1054ba4 (earliest release - 4.1.0)
     rv = bytearray()
     for i, d in enumerate(src):
@@ -206,8 +242,10 @@ def peers_convert_from_bencoded(src: BencodeList, key: bytes):
     return bytes(rv)
 
 
-def transmission_get_peers(resume_data: BencodeData, addr_size: int, key: bytes):
-    src = resume_data.data.get(key)
+def transmission_get_peers(
+    resume_data: BencodeDictWrapper, addr_size: int, key: bytes
+) -> bytes:
+    src = resume_data.unwrap().get(key)
     if src is None:
         return b""
 
@@ -220,7 +258,7 @@ def transmission_get_peers(resume_data: BencodeData, addr_size: int, key: bytes)
     raise ConversionError(f"{key} is not a list or a bytes")
 
 
-def transmission_get_limit(tr_resume: BencodeData, limit_kind: str):
+def transmission_get_limit(tr_resume: BencodeDictWrapper, limit_kind: str) -> int:
     limit_key = f"{limit_kind}-limit".encode()
     mode_key = f"{limit_kind}-mode".encode()
 
@@ -241,7 +279,7 @@ def transmission_get_limit(tr_resume: BencodeData, limit_kind: str):
 BLOCK_SIZE = 1 << 14  # 16KiB, standard across torrents
 
 
-def get_last_piece_mask_for_block_checking(torrent_size: int, piece_size: int):
+def get_last_piece_mask_for_block_checking(torrent_size: int, piece_size: int) -> bytes:
     # We use masks to determine if torrent pieces are on disk, by extracting progress info
     # from the Transmission resume for the pieces and comparing them to the mask.
     # This method creates the mask for the last piece of the torrent, which is not as trivial
@@ -270,7 +308,9 @@ def get_last_piece_mask_for_block_checking(torrent_size: int, piece_size: int):
     return piece_mask
 
 
-def transmission_get_pieces(parsed_tor: BencodeData, tr_resume: BencodeData):
+def transmission_get_pieces(
+    parsed_tor: BencodeDictWrapper, tr_resume: BencodeDictWrapper
+) -> bytes:
     info = parsed_tor.get_dict(b"info")
     torrent_size = info.get(int, b"length")
     piece_size = info.get(int, b"piece length")
@@ -330,8 +370,8 @@ def transmission_get_pieces(parsed_tor: BencodeData, tr_resume: BencodeData):
 
 
 def map_resume_to_qbt(
-    info_hash: str, parsed_tor: BencodeData, resume_data: BencodeData
-):
+    info_hash: str, parsed_tor: BencodeDictWrapper, resume_data: BencodeDictWrapper
+) -> BencodeDict:
     downloading_time_seconds = resume_data.get(int, b"downloading-time-seconds")
     seeding_time_seconds = resume_data.get(int, b"seeding-time-seconds")
     name = resume_data.get(bytes, b"name")
@@ -374,13 +414,13 @@ def map_resume_to_qbt(
     if group is not None:
         qbt_resume_data[b"qBt-category"] = group
 
-    labels = resume_data.get_list(b"labels", optional=True)
+    labels = resume_data.get_list(bytes, b"labels", optional=True)
     if labels is not None:
-        qbt_resume_data[b"qBt-tags"] = labels
+        qbt_resume_data[b"qBt-tags"] = labels.unwrap()
 
-    files = resume_data.get_list(b"files", optional=True)
+    files = resume_data.get_list(bytes, b"files", optional=True)
     if files is not None:
-        qbt_resume_data[b"mapped_files"] = files
+        qbt_resume_data[b"mapped_files"] = files.unwrap()
 
     incomplete_dir = resume_data.get(bytes, b"incomplete_dir", optional=True)
     if incomplete_dir is not None:
@@ -401,7 +441,7 @@ class Args:
 
 
 class TransmissionQbtImporter:
-    def __init__(self, args: Args):
+    def __init__(self, args: Args) -> None:
         check_for_qbt_sqlite_resume_db(args.qbt_bt_backup_dir)
         self.source_torrents_dir = os.path.join(
             args.transmission_config_dir, "torrents"
@@ -416,9 +456,9 @@ class TransmissionQbtImporter:
         self,
         source_tor_abs_path: str,
         info_hash: str,
-        parsed_tor: BencodeData,
-        resume_data: BencodeData,
-    ):
+        parsed_tor: BencodeDictWrapper,
+        resume_data: BencodeDictWrapper,
+    ) -> None:
         qbt_resume_data = map_resume_to_qbt(info_hash, parsed_tor, resume_data)
         qbt_resume_path = os.path.join(self.target_dir, info_hash + ".fastresume")
         qbt_torrent_path = os.path.join(self.target_dir, info_hash + ".torrent")
@@ -442,13 +482,13 @@ class TransmissionQbtImporter:
         source_tor_abs_path: str,
         source_res_abs_path: str,
         info_hash: str | None,
-    ):
+    ) -> None:
         parsed_tor = get_data("torrent", source_tor_abs_path)
 
         resume_data = get_data("resume", source_res_abs_path)
 
         if info_hash is None:
-            info_hash = calc_info_hash(parsed_tor).hexdigest()
+            info_hash = calc_info_hash(parsed_tor)
 
         if self.predicate is None:
             predicate_rv = True
@@ -468,7 +508,7 @@ class TransmissionQbtImporter:
                 f"Predicate returned {predicate_rv} for torrent {info_hash}, skipping"
             )
 
-    def import_one(self, torf: str):
+    def import_one(self, torf: str) -> None:
         match = self.torrent_file_300_rgx.fullmatch(torf)
         if match:
             info_hash = match[1]
@@ -492,7 +532,7 @@ class TransmissionQbtImporter:
 
         logging.warning(f"Unknown file {torf} found in torrents directory, skipping")
 
-    def scan(self):
+    def scan(self) -> None:
         for _, _, files in os.walk(self.source_torrents_dir):
             for torf in files:
                 try:
@@ -510,7 +550,7 @@ class TransmissionQbtImporter:
                     logging.warning(f"Failed to decode {str(e)}, skipping")
 
 
-def main():
+def main() -> int:
     logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(message)s")
     parser = argparse.ArgumentParser(
         prog="transmission2qbt",

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -225,6 +225,48 @@ def transmission_get_limit(resume: BencodeDict, limit_kind: str) -> int:
             raise ConversionError(f"unknown value for {mode_key} : {limit_mode}")
 
 
+# On transmission_get_pieces & is_piece_complete
+#
+# The blocks data the in Transmission resume (tr_blocks) is a bitmask in the form of a bytes object (an immutable array of bytes, aka a
+# binary string).
+# Each byte represents 8 blocks: each bit in that byte represents a single block, i.e. a 16KiB chunk of torrent data.
+# Each bit is equal to 1 if the block is on disk, 0 if not.
+#
+# The pieces data in the qBittorrent/libtorrent resume (qb_pieces) is also a bytes object but not a bitmask: each byte represent a piece,
+# and is equal to 0x01 if the piece is on disk, 0x00 if not (only one of the 8 bits is used in each byte, the first 7 bits are always 0).
+#
+# Blocks are the atomic amount of data used for storage. Pieces are used in the hash calculation (in Bittorrent v1), the protocol, and in
+# the resume files, such as qb_pieces here.
+# There is an additional field (unfinished) in the qBittorrent resume to store block info for incomplete pieces, but this field is ignored
+# here, see README.md.
+#
+# The piece size is a multiple of the block size, but not always a multiple of 8*16KiB (the data chunk represented by a tr_blocks byte).
+# Which means that a tr_blocks byte might represent more than one qb_pieces byte, and vice versa; it also means that the first block of each
+# piece will not necessarily be aligned with the leftmost bit of a tr_blocks byte.
+#
+# So to understand which pieces are fully on disk (which is what we need to build qb_pieces), we need to extract piece_blocks for each piece
+# in tr_blocks, and check if they are all 1.
+# We start by finding what tr_block byte the piece starts and ends with. It might start midway through a byte (i.e. not the leftmost bit of
+# the start byte) and likewise it might end midway through a byte (not the rightmost bit of the end byte). For this reason the first and last
+# byte are checked using a bitwise masking operation, with a precalculated dict of masks indexed with the order of the first and last bit.
+# For instance, if the start bit order is 3, then the mask is 00011111 (0x1f). We mask the byte coming from tr_blocks against this
+# i.e. tr_blocks[piece_start] & 0x1f == 0x1f. The masks for the end bit order are reversed i.e. if the bit order is 3, the mask is
+# 11110000 (0xf0) so we will check if tr_blocks[piece_end] & 0xf0 == 0xf0.
+# All the tr_blocks bytes between the first and the last are fully part of the piece, so if the piece is complete the block bytes are all
+# 0xff. No need to mask for these, we can just compare them all to 0xff.
+#
+# There is a special case when a piece is fully contained within a block byte (which only happens when the piece length is <= 8*16KiB).
+# In this case there is only one block byte to check and we need to mask it against both the start and end mask.
+#
+# We also need to take in account that the total number of blocks might not align with the end of a piece, i.e. the last piece can be smaller.
+#
+# In another special case, tr_blocks might contain fewer bytes than expected, because Transmission does not write the end of tr_blocks when the
+# end of the torrent is not on disk (it will only write up to the last block that is on disk). For that reason when retrieving a piece we might
+# get fewer bytes than expected. In that case we need to return False since it means that the piece is not on disk.
+#
+# Finally, Transmission sets the whole tr_blocks to b"all" for complete torrents and b"none" for empty torrents, so these special cases must
+# be dealt with separately.
+
 BLOCK_SIZE = 1 << 14  # 16KiB, standard across torrents
 FIRST_BYTE_MASK_BY_BIT_ORDER = {i: 0xFF >> i for i in range(0, 8)}
 LAST_BYTE_MASK_BY_BIT_ORDER = {i: 0xFF << 7 - i & 0xFF for i in range(0, 8)}
@@ -233,46 +275,6 @@ LAST_BYTE_MASK_BY_BIT_ORDER = {i: 0xFF << 7 - i & 0xFF for i in range(0, 8)}
 def is_piece_complete(
     tr_blocks: bytes, piece_index: int, blocks_per_piece: int, num_blocks: int
 ):
-    # The blocks data the in Transmission resume (tr_blocks) is a bitmask in the form of a bytes object (an immutable array of bytes, aka a
-    # binary string).
-    # Each byte represents 8 blocks: each bit in that byte represents a single block, i.e. a 16KiB chunk of torrent data.
-    # Each bit is equal to 1 if the block is on disk, 0 if not.
-    #
-    # The pieces data in the qBittorrent/libtorrent resume (qb_pieces) is also a bytes object but not a bitmask: each byte represent a piece,
-    # and is equal to 0x01 if the piece is on disk, 0x00 if not (only one of the 8 bits is used in each byte, the first 7 bits are always 0).
-    #
-    # Blocks are the atomic amount of data used for storage. Pieces are used in the hash calculation (in Bittorrent v1), the protocol, and in
-    # the resume files, such as qb_pieces here.
-    # There is an additional field (unfinished) in the qBittorrent resume to store block info for incomplete pieces, but this field is ignored
-    # here, see README.md.
-    #
-    # The piece size is a multiple of the block size, but not always a multiple of 8*16KiB (the data chunk represented by a tr_blocks byte).
-    # Which means that a tr_blocks byte might represent more than one qb_pieces byte, and vice versa; it also means that the first block of each
-    # piece will not necessarily be aligned with the leftmost bit of a tr_blocks byte.
-    #
-    # So to understand which pieces are fully on disk (which is what we need to build qb_pieces), we need to extract piece_blocks for each piece
-    # in tr_blocks, and check if they are all 1.
-    # We start by finding what tr_block byte the piece starts and ends with. It might start midway through a byte (i.e. not the leftmost bit of
-    # the start byte) and likewise it might end midway through a byte (not the rightmost bit of the end byte). For this reason the first and last
-    # byte are checked using a bitwise masking operation, with a precalculated dict of masks indexed with the order of the first and last bit.
-    # For instance, if the start bit order is 3, then the mask is 00011111 (0x1f). We mask the byte coming from tr_blocks against this
-    # i.e. tr_blocks[piece_start] & 0x1f == 0x1f. The masks for the end bit order are reversed i.e. if the bit order is 3, the mask is
-    # 11110000 (0xf0) so we will check if tr_blocks[piece_end] & 0xf0 == 0xf0.
-    # All the tr_blocks bytes between the first and the last are fully part of the piece, so if the piece is complete the block bytes are all
-    # 0xff. No need to mask for these, we can just compare them all to 0xff.
-    #
-    # There is a special case when a piece is fully contained within a block byte (which only happens when the piece length is <= 8*16KiB).
-    # In this case there is only one block byte to check and we need to mask it against both the start and end mask.
-    #
-    # We also need to take in account that the total number of blocks might not align with the end of a piece, i.e. the last piece can be smaller.
-    #
-    # In another special case, tr_blocks might contain fewer bytes than expected, because Transmission does not write the end of tr_blocks when the
-    # end of the torrent is not on disk (it will only write up to the last block that is on disk). For that reason when retrieving a piece we might
-    # get fewer bytes than expected. In that case we need to return False since it means that the piece is not on disk.
-    #
-    # Finally, Transmission sets the whole tr_blocks to b"all" for complete torrents and b"none" for empty torrents, so these special cases must
-    # be dealt with separately.
-
     # Indexes of the first block of the piece
     # In total blocks
     piece_start_in_overall_blocks = piece_index * blocks_per_piece

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -95,7 +95,7 @@ class BencodeData:
             raise ConversionError(f"{self.path}.{key.decode()} missing")
 
         if not isinstance(result, list):
-            raise ConversionError(f"{self.path}.{key.decode()} is not {type}")
+            raise ConversionError(f"{self.path}.{key.decode()} is not list")
 
         return result
 
@@ -115,7 +115,7 @@ class BencodeData:
             raise ConversionError(f"{self.path}.{key.decode()} missing")
 
         if not isinstance(result, dict):
-            raise ConversionError(f"{self.path}.{key.decode()} is not {type}")
+            raise ConversionError(f"{self.path}.{key.decode()} is not dict")
 
         return BencodeData(f"{self.path}.{key.decode()}", result)
 
@@ -250,24 +250,99 @@ def transmission_get_limit(tr_resume: BencodeData, limit_kind: str):
             raise ConversionError(f"unknown value for {mode_key} : {limit_mode}")
 
 
-BIT_LOOKUP = [bytes(n >> i & 1 for i in range(7, -1, -1)) for n in range(256)]
+BLOCK_SIZE = 1 << 14  # 16KiB, standard across torrents
 
 
-def transmission_get_pieces(tr_resume: BencodeData, num_pieces: int):
-    tr_piece_bytes = tr_resume.get_dict(b"progress").get_bytes(b"pieces")
-    match tr_piece_bytes:
-        case b"all":
-            return b"\1" * num_pieces
-        case b"none":
-            return b"\0" * num_pieces
-        case _:
-            qb_pieces = bytearray()
-            for tr_piece_byte in tr_piece_bytes:
-                qb_pieces += BIT_LOOKUP[tr_piece_byte]
-            return bytes(qb_pieces[:num_pieces].ljust(num_pieces, b"\0"))
+def get_last_piece_mask_for_block_checking(torrent_size: int, piece_size: int):
+    # We use masks to determine if torrent pieces are on disk, by extracting progress info
+    # from the Transmission resume for the pieces and comparing them to the mask.
+    # This method creates the mask for the last piece of the torrent, which is not as trivial
+    # as for the other pieces (where the mask is just 1s)
+    # This method is used by transmission_get_pieces
+
+    # Size of the last piece
+    # Note that in the special case where the torrent size is a multiple of the piece size,
+    # the last piece has the same size as all the other pieces
+    last_piece_size = torrent_size % piece_size or piece_size
+
+    # Number of blocks in the last piece
+    blocks_in_last_piece = -(-last_piece_size // BLOCK_SIZE)  # Ceiling integer division
+
+    # Get the start of the mask, made of 1s in groups of 8
+    mask_full_bytes = blocks_in_last_piece // 8
+    piece_mask = b"\xff" * mask_full_bytes
+
+    # Append last byte of the mask: 1s followed by 0s
+    mask_extra_bits = blocks_in_last_piece % 8
+    if mask_extra_bits:
+        # Create a byte made of n 1s followed by (8-n) 0s
+        piece_mask += bytes([0xFF << 8 - mask_extra_bits & 0xFF])
+
+    return piece_mask
 
 
-def map_resume_to_qbt(resume_data: BencodeData, info_hash: str, num_pieces: int):
+def transmission_get_pieces(parsed_tor: BencodeData, tr_resume: BencodeData):
+    info = parsed_tor.get_dict(b"info")
+    torrent_size = info.get_int(b"length")
+    piece_size = info.get_int(b"piece length")
+
+    # Sanity check the piece length
+    if piece_size & -piece_size != piece_size:  # This is only true for powers of 2
+        raise ConversionError(f"Piece size {piece_size} is not a power of 2")
+    # The progress.blocks bytes in the Transmission resume contain 1 bit per data block (where bit=1 means the block is on disk)
+    # So each byte in progress.blocks represents 8 blocks
+    # The pieces bytes in the qBittorrent resume contains a full byte per piece, where 0x01 means the piece is on disk
+    # The algorithm in this method determines if a piece is complete by extracting progress.blocks bytes in groups of n
+    # (where n=piece_size//BLOCK_SIZE//8), and checking that they are all 0xff
+    # For this to work without having to do bitwise operations, the piece size must be at least 8x the block size
+    # The block size is 16KiB so the minimum piece size is 128KiB
+    if piece_size < 1 << 17:  # 128KiB
+        raise ConversionError(f"Piece size {piece_size} is lower than 128KiB, aborting")
+
+    blocks = tr_resume.get_dict(b"progress").get_bytes(b"blocks")
+
+    # Sanity check the block bytes length
+    expected_num_blocks = -(
+        -torrent_size // BLOCK_SIZE // 8
+    )  # ceiling integer division
+    if len(blocks) != expected_num_blocks:
+        raise ConversionError(
+            f"resume block length was expected to be {expected_num_blocks} but was {len(blocks)}"
+        )
+
+    num_pieces = -(-torrent_size // piece_size)  # ceiling integer division
+
+    # Initialise the return object with 0s
+    qbit_pieces = bytearray(num_pieces)
+
+    blocks_per_piece = piece_size // BLOCK_SIZE
+    block_bytes_per_piece = blocks_per_piece // 8
+
+    # What a full piece looks like in progress.blocks
+    full_piece_mask = b"\xff" * block_bytes_per_piece
+
+    # Go through progress.blocks, grouping them into pieces
+    # We skip the last piece because it is a special case, see below
+    for piece_index in range(num_pieces):
+        piece_start = piece_index * block_bytes_per_piece
+        piece_blocks = blocks[piece_start : piece_start + block_bytes_per_piece]
+
+        # The last piece is special: if it is not exactly 128KiB then progress.blocks does not end with 0xff even when complete
+        # So we need to calculate the expected mask, then compare it to the last byte(s) of the blocks object
+        if piece_index == num_pieces - 1:
+            full_piece_mask = get_last_piece_mask_for_block_checking(
+                torrent_size, piece_size
+            )
+
+        if piece_blocks == full_piece_mask:
+            qbit_pieces[piece_index] = 1
+
+    return bytes(qbit_pieces)
+
+
+def map_resume_to_qbt(
+    info_hash: str, parsed_tor: BencodeData, resume_data: BencodeData
+):
     downloading_time_seconds = resume_data.get_int(b"downloading-time-seconds")
     seeding_time_seconds = resume_data.get_int(b"seeding-time-seconds")
     name = resume_data.get_bytes(b"name")
@@ -303,6 +378,7 @@ def map_resume_to_qbt(resume_data: BencodeData, info_hash: str, num_pieces: int)
             transmission_get_limit(resume_data, "idle")
         ),
         b"qBt-savePath": resume_data.get_bytes(b"destination"),
+        b"pieces": transmission_get_pieces(parsed_tor, resume_data),
     }
 
     group = resume_data.get_bytes(b"group", optional=True)
@@ -324,8 +400,6 @@ def map_resume_to_qbt(resume_data: BencodeData, info_hash: str, num_pieces: int)
     paused = resume_data.get_int(b"paused")
     if paused == 1:
         qbt_resume_data[b"auto_managed"] = 0
-
-    qbt_resume_data[b"pieces"] = transmission_get_pieces(resume_data, num_pieces)
 
     return qbt_resume_data
 
@@ -353,10 +427,10 @@ class TransmissionQbtImporter:
         self,
         source_tor_abs_path: str,
         info_hash: str,
-        num_pieces: int,
+        parsed_tor: BencodeData,
         resume_data: BencodeData,
     ):
-        qbt_resume_data = map_resume_to_qbt(resume_data, info_hash, num_pieces)
+        qbt_resume_data = map_resume_to_qbt(info_hash, parsed_tor, resume_data)
         qbt_resume_path = os.path.join(self.target_dir, info_hash + ".fastresume")
         qbt_torrent_path = os.path.join(self.target_dir, info_hash + ".torrent")
         try:
@@ -387,8 +461,6 @@ class TransmissionQbtImporter:
         if info_hash is None:
             info_hash = calc_info_hash(parsed_tor).hexdigest()
 
-        num_pieces = len(parsed_tor.get_dict(b"info").get_list(b"pieces")) // 20
-
         if self.predicate is None:
             predicate_rv = True
         else:
@@ -401,7 +473,7 @@ class TransmissionQbtImporter:
                 return
 
         if predicate_rv is True:
-            self.copy_to_target(source_tor_abs_path, info_hash, num_pieces, resume_data)
+            self.copy_to_target(source_tor_abs_path, info_hash, parsed_tor, resume_data)
         else:
             logging.info(
                 f"Predicate returned {predicate_rv} for torrent {info_hash}, skipping"

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -288,6 +288,7 @@ def transmission_get_pieces(parsed_tor: BencodeData, tr_resume: BencodeData):
     piece_size = info.get_int(b"piece length")
 
     # Sanity check the piece length
+    # Only accept piece size in powers of 2
     if piece_size & -piece_size != piece_size:  # This is only true for powers of 2
         raise ConversionError(f"Piece size {piece_size} is not a power of 2")
     # The progress.blocks bytes in the Transmission resume contain 1 bit per data block (where bit=1 means the block is on disk)
@@ -323,7 +324,6 @@ def transmission_get_pieces(parsed_tor: BencodeData, tr_resume: BencodeData):
     full_piece_mask = b"\xff" * block_bytes_per_piece
 
     # Go through progress.blocks, grouping them into pieces
-    # We skip the last piece because it is a special case, see below
     for piece_index in range(num_pieces):
         piece_start = piece_index * block_bytes_per_piece
         piece_blocks = blocks[piece_start : piece_start + block_bytes_per_piece]

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -49,50 +49,50 @@ class BencodeNode[T: BencodeType](NamedTuple):
 type BencodeDict = BencodeNode[dict[bytes, BencodeType]]
 
 
-def build_bencode_node[T: BencodeType](
-    type_dest: type[T], value: BencodeType, path: str
+def build_node[T: BencodeType](
+    type: type[T], value: BencodeType, path: str
 ) -> BencodeNode[T]:
     # origin is the parent class for generics (e.g. list for list[int])
     # origin is none for non-generics
     # isinstance does not work on generics but it works on the origin of a generic
     # cast works on the generic itself so type inference works
-    typecheck = get_origin(type_dest) or type_dest
+    typecheck = get_origin(type) or type
     if not isinstance(value, typecheck):
         raise ConversionError(f"f{path} is not of type {typecheck}")
     return BencodeNode(cast(T, value), path)
 
 
 @overload
-def get[T: BencodeType](
-    type_dest: type[T],
-    data: BencodeNode[dict[bytes, BencodeType]],
-    key: bytes,
+def get_child[T: BencodeType](
+    parent: BencodeNode[dict[bytes, BencodeType]],
+    child_name: bytes,
+    child_type: type[T],
     *,
     default: T | None = None,
 ) -> BencodeNode[T]: ...
 @overload
-def get[T: BencodeType](
-    type_dest: type[T],
-    data: BencodeNode[dict[bytes, BencodeType]],
-    key: bytes,
+def get_child[T: BencodeType](
+    parent: BencodeNode[dict[bytes, BencodeType]],
+    child_name: bytes,
+    child_type: type[T],
     *,
     optional: Literal[True],
 ) -> BencodeNode[T] | None: ...
-def get[T: BencodeType](
-    type_dest: type[T],
-    data: BencodeNode[dict[bytes, BencodeType]],
-    key: bytes,
+def get_child[T: BencodeType](
+    parent: BencodeNode[dict[bytes, BencodeType]],
+    child_name: bytes,
+    child_type: type[T],
     *,
     default: T | None = None,
     optional: bool = False,
 ) -> BencodeNode[T] | None:
-    value = data.value.get(key, default)
-    path = f"{data.path}.{key.decode()}"
-    if value is None:
+    child_value = parent.value.get(child_name, default)
+    child_path = f"{parent.path}.{child_name.decode()}"
+    if child_value is None:
         if optional:
             return None
-        raise ConversionError(f"{path} is missing")
-    return build_bencode_node(type_dest, value, path)
+        raise ConversionError(f"{child_path} is missing")
+    return build_node(child_type, child_value, child_path)
 
 
 def bencode(data: BencodeType) -> bytes:
@@ -109,34 +109,34 @@ def check_for_qbt_sqlite_resume_db(qbt_bt_backup_dir: str) -> None:
         raise QbtUsesSqliteForResumeError()
 
 
-def get_data(root_path: str, file_path: str) -> BencodeDict:
+def get_data(file_path: str, node_path: str) -> BencodeDict:
     with open(file_path, "rb") as f:
         try:
             decoded = bdecode(f.read())
         except (ValueError, bencodepy.BencodeDecodeError) as e:
             raise ReadBencodedError(file_path) from e
-    return build_bencode_node(dict[bytes, BencodeType], decoded, root_path)
+    return build_node(dict[bytes, BencodeType], decoded, node_path)
 
 
 # FIXME BEP0003 says that clients must not perform a decode-encode
 # roundtrip on invalid data. this is exactly what this does.
-def calc_info_hash(parsed_tor: BencodeDict) -> str:
-    info, _ = get(dict[bytes, BencodeType], parsed_tor, b"info")
+def calc_info_hash(torrent: BencodeDict) -> str:
+    info, _ = get_child(torrent, b"info", dict[bytes, BencodeType])
     return hashlib.sha1(bencode(info)).hexdigest()
 
 
-def transmission_get_speed_limit(resume_data: BencodeDict, key: bytes) -> int:
-    speed_limit_obj = get(dict[bytes, BencodeType], resume_data, key)
-    use_speed_limit, _ = get(int, speed_limit_obj, b"use-speed-limit")
+def transmission_get_speed_limit(resume: BencodeDict, key: bytes) -> int:
+    speed_limit_obj = get_child(resume, key, dict[bytes, BencodeType])
+    use_speed_limit, _ = get_child(speed_limit_obj, b"use-speed-limit", int)
     if use_speed_limit != 0:
-        return get(int, speed_limit_obj, b"speed-Bps").value
+        return get_child(speed_limit_obj, b"speed-Bps", int).value
 
     return -1
 
 
-def transmission_get_file_prorities(resume_data: BencodeDict) -> Generator[int]:
-    priority_node = get(list[BencodeType], resume_data, b"priority", optional=True)
-    dnd_node = get(list[BencodeType], resume_data, b"dnd", optional=True)
+def transmission_get_file_prorities(resume: BencodeDict) -> Generator[int]:
+    priority_node = get_child(resume, b"priority", list[BencodeType], optional=True)
+    dnd_node = get_child(resume, b"dnd", list[BencodeType], optional=True)
 
     # Return empty list if priority data is not available
     if priority_node is None or dnd_node is None:
@@ -182,16 +182,14 @@ def peers_convert_from_bencoded(src: list[BencodeType], key: bytes) -> bytes:
     rv = bytearray()
     for i, d in enumerate(src):
         d_path = f"{key}[{i}]"
-        d_dict = build_bencode_node(dict[bytes, BencodeType], d, d_path)
-        socket_address = get(bytes, d_dict, b"socket_address").value
+        d_dict = build_node(dict[bytes, BencodeType], d, d_path)
+        socket_address = get_child(d_dict, b"socket_address", bytes).value
         rv += socket_address
     return bytes(rv)
 
 
-def transmission_get_peers(
-    resume_data: BencodeDict, addr_size: int, key: bytes
-) -> bytes:
-    src = resume_data.value.get(key)
+def transmission_get_peers(resume: BencodeDict, addr_size: int, key: bytes) -> bytes:
+    src = resume.value.get(key)
     if src is None:
         return b""
 
@@ -204,18 +202,18 @@ def transmission_get_peers(
     raise ConversionError(f"{key} is not a list or bytes")
 
 
-def transmission_get_limit(tr_resume: BencodeDict, limit_kind: str) -> int:
+def transmission_get_limit(resume: BencodeDict, limit_kind: str) -> int:
     limit_key = f"{limit_kind}-limit".encode()
-    limit_obj = get(dict[bytes, BencodeType], tr_resume, limit_key)
+    limit_obj = get_child(resume, limit_key, dict[bytes, BencodeType])
 
     mode_key = f"{limit_kind}-mode".encode()
-    limit_mode, _ = get(int, limit_obj, mode_key)
+    limit_mode, _ = get_child(limit_obj, mode_key, int)
 
     match limit_mode:
         case 0:  # TR_*LIMIT_GLOBAL
             return -2  # BitTorrent::Torrent::USE_GLOBAL_*
         case 1:  # TR_*LIMIT_SINGLE
-            return get(int, limit_obj, limit_key).value
+            return get_child(limit_obj, limit_key, int).value
         case 2:  # TR_*LIMIT_UNLIMITED
             return -1  # BitTorrent::Torrent::NO_*_LIMIT
         case _:
@@ -254,10 +252,10 @@ def get_last_piece_mask_for_block_checking(torrent_size: int, piece_size: int) -
     return piece_mask
 
 
-def transmission_get_pieces(parsed_tor: BencodeDict, tr_resume: BencodeDict) -> bytes:
-    info = get(dict[bytes, BencodeType], parsed_tor, b"info")
-    torrent_size, _ = get(int, info, b"length")
-    piece_size, _ = get(int, info, b"piece length")
+def transmission_get_pieces(torrent: BencodeDict, resume: BencodeDict) -> bytes:
+    info = get_child(torrent, b"info", dict[bytes, BencodeType])
+    torrent_size, _ = get_child(info, b"length", int)
+    piece_size, _ = get_child(info, b"piece length", int)
 
     # Sanity check the piece length
     # Only accept piece size in powers of 2
@@ -273,8 +271,8 @@ def transmission_get_pieces(parsed_tor: BencodeDict, tr_resume: BencodeDict) -> 
     if piece_size < 1 << 17:  # 128KiB
         raise ConversionError(f"Piece size {piece_size} is lower than 128KiB, aborting")
 
-    progress = get(dict[bytes, BencodeType], tr_resume, b"progress")
-    blocks, _ = get(bytes, progress, b"blocks")
+    progress = get_child(resume, b"progress", dict[bytes, BencodeType])
+    blocks, _ = get_child(progress, b"blocks", bytes)
 
     # Sanity check the block bytes length
     # ceiling integer division
@@ -315,62 +313,58 @@ def transmission_get_pieces(parsed_tor: BencodeDict, tr_resume: BencodeDict) -> 
 
 
 def map_resume_to_qbt(
-    info_hash: str, parsed_tor: BencodeDict, resume_data: BencodeDict
+    info_hash: str, torrent: BencodeDict, resume: BencodeDict
 ) -> dict[bytes, BencodeType]:
-    downloading_time_seconds, _ = get(int, resume_data, b"downloading-time-seconds")
-    seeding_time_seconds, _ = get(int, resume_data, b"seeding-time-second")
-    name, _ = get(bytes, resume_data, b"name")
-    paused, __ = get(int, resume_data, b"paused")
+    downloading_time_seconds, _ = get_child(resume, b"downloading-time-seconds", int)
+    seeding_time_seconds, _ = get_child(resume, b"seeding-time-second", int)
+    name, _ = get_child(resume, b"name", bytes)
+    paused, __ = get_child(resume, b"paused", int)
 
     qbt_resume_data: BencodeType = {
         b"file-format": b"libtorrent resume file",
         b"file-version": 1,
         b"info-hash": binascii.unhexlify(info_hash),
         b"name": name,
-        b"total_uploaded": get(int, resume_data, b"uploaded").value,
-        b"total_downloaded": get(int, resume_data, b"downloaded").value,
-        b"added_time": get(int, resume_data, b"added-date").value,
-        b"completed_time": get(int, resume_data, b"done-date").value,
+        b"total_uploaded": get_child(resume, b"uploaded", int).value,
+        b"total_downloaded": get_child(resume, b"downloaded", int).value,
+        b"added_time": get_child(resume, b"added-date", int).value,
+        b"completed_time": get_child(resume, b"done-date", int).value,
         b"active_time": downloading_time_seconds + seeding_time_seconds,
         b"finished_time": downloading_time_seconds,
         b"seeding_time": seeding_time_seconds,
-        b"max_connections": get(int, resume_data, b"max-peers").value,
-        b"upload_rate_limit": transmission_get_speed_limit(
-            resume_data, b"speed-limit-up"
-        ),
+        b"max_connections": get_child(resume, b"max-peers", int).value,
+        b"upload_rate_limit": transmission_get_speed_limit(resume, b"speed-limit-up"),
         b"download_rate_limit": transmission_get_speed_limit(
-            resume_data, b"speed-limit-down"
+            resume, b"speed-limit-down"
         ),
-        b"save_path": get(bytes, resume_data, b"destination").value,
+        b"save_path": get_child(resume, b"destination", bytes).value,
         b"paused": paused,
-        b"sequential_download": get(
-            int, resume_data, b"sequentialDownload", default=0
+        b"sequential_download": get_child(
+            resume, b"sequentialDownload", int, default=0
         ).value,
-        b"file_priority": list(transmission_get_file_prorities(resume_data)),
-        b"peers": transmission_get_peers(resume_data, 4, b"peers2"),
-        b"peers6": transmission_get_peers(resume_data, 16, b"peers2-6"),
+        b"file_priority": list(transmission_get_file_prorities(resume)),
+        b"peers": transmission_get_peers(resume, 4, b"peers2"),
+        b"peers6": transmission_get_peers(resume, 16, b"peers2-6"),
         b"qBt-name": name,
-        b"qBt-ratioLimit": transmission_get_limit(resume_data, "ratio"),
-        b"qBt-inactiveSeedingTimeLimit": int(
-            transmission_get_limit(resume_data, "idle")
-        ),
-        b"qBt-savePath": get(bytes, resume_data, b"destination").value,
-        b"pieces": transmission_get_pieces(parsed_tor, resume_data),
+        b"qBt-ratioLimit": transmission_get_limit(resume, "ratio"),
+        b"qBt-inactiveSeedingTimeLimit": int(transmission_get_limit(resume, "idle")),
+        b"qBt-savePath": get_child(resume, b"destination", bytes).value,
+        b"pieces": transmission_get_pieces(torrent, resume),
     }
 
-    group = get(bytes, resume_data, b"group", optional=True)
+    group = get_child(resume, b"group", bytes, optional=True)
     if group is not None:
         qbt_resume_data[b"qBt-category"] = group.value
 
-    labels = get(list[BencodeType], resume_data, b"labels", optional=True)
+    labels = get_child(resume, b"labels", list[BencodeType], optional=True)
     if labels is not None:
         qbt_resume_data[b"qBt-tags"] = labels.value
 
-    files = get(list[BencodeType], resume_data, b"files", optional=True)
+    files = get_child(resume, b"files", list[BencodeType], optional=True)
     if files is not None:
         qbt_resume_data[b"mapped_files"] = files.value
 
-    incomplete_dir = get(bytes, resume_data, b"incomplete_dir", optional=True)
+    incomplete_dir = get_child(resume, b"incomplete_dir", bytes, optional=True)
     if incomplete_dir is not None:
         qbt_resume_data[b"qBt-downloadPath"] = incomplete_dir.value
 
@@ -403,10 +397,10 @@ class TransmissionQbtImporter:
         self,
         source_tor_abs_path: str,
         info_hash: str,
-        parsed_tor: BencodeDict,
-        resume_data: BencodeDict,
+        torrent: BencodeDict,
+        resume: BencodeDict,
     ) -> None:
-        qbt_resume_data = map_resume_to_qbt(info_hash, parsed_tor, resume_data)
+        qbt_resume_data = map_resume_to_qbt(info_hash, torrent, resume)
         qbt_resume_path = os.path.join(self.target_dir, info_hash + ".fastresume")
         qbt_torrent_path = os.path.join(self.target_dir, info_hash + ".torrent")
         try:
@@ -430,12 +424,12 @@ class TransmissionQbtImporter:
         source_res_abs_path: str,
         info_hash: str | None,
     ) -> None:
-        parsed_tor = get_data("torrent", source_tor_abs_path)
+        torrent = get_data(source_tor_abs_path, "torrent")
 
-        resume_data = get_data("resume", source_res_abs_path)
+        resume = get_data(source_res_abs_path, "resume")
 
         if info_hash is None:
-            info_hash = calc_info_hash(parsed_tor)
+            info_hash = calc_info_hash(torrent)
 
         if self.predicate is None:
             predicate_rv = True
@@ -449,7 +443,7 @@ class TransmissionQbtImporter:
                 return
 
         if predicate_rv is True:
-            self.copy_to_target(source_tor_abs_path, info_hash, parsed_tor, resume_data)
+            self.copy_to_target(source_tor_abs_path, info_hash, torrent, resume)
         else:
             logging.info(
                 f"Predicate returned {predicate_rv} for torrent {info_hash}, skipping"

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -419,20 +419,20 @@ def transmission_get_files(
     # (multi-file torrents).
     tr_name = resume.get(bytes, b"name")
 
-    # Files as defined in the torrent
+    # Files as defined in the torrent.
     tor_files = torrent_info.get(BencodeList, b"files", optional=True)
     if tor_files is None:
-        # Single-file torrent, return the resume name,
+        # Single-file torrent, return the resume name.
         return [tr_name]
 
-    # Files as defined in the Transmission resume
+    # Files as defined in the Transmission resume.
     tr_files = resume.get(BencodeList, b"files", optional=True)
     if tr_files is None:
-        # If we do not have access to this data, None is valid for qBittorrent as it will use the
-        # default names (the ones defined in the torrent)
+        # If we do not have access to this data, None is a valid value for qBittorrent as it will
+        # use the default names (the ones defined in the torrent).
         return None
 
-    # Files as defined in the qBittorrent resume (what we are calculating)
+    # Files as defined in the qBittorrent resume (what we are calculating).
     qbit_files = list[BencodeType]()
 
     tr_index = 0

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -50,6 +50,10 @@ def decode(data: bytes) -> BencodeType:
 
 
 def wrap[T: BencodeWrap](t: type[T], node: BencodeType, path: str) -> T:
+    """Wraps a bencode type.
+     dicts and lists are wrapped in BencodeList and BencodeDict respectively.
+     Scalar types (bytes & int) are typechecked and returned as is."""
+
     if t is BencodeList:
         if not isinstance(node, list):
             raise ConversionError(f"f{path} is not of type list")
@@ -64,30 +68,50 @@ def wrap[T: BencodeWrap](t: type[T], node: BencodeType, path: str) -> T:
 
 
 class BencodeList:
+    """Wraps a bencode list. Allows retrieving items by index or enumerating them while typechecking them."""
+
     def __init__(self, node: list[BencodeType], path: str) -> None:
         self._node = node
         self._path = path
 
+    def __len__(self):
+        return len(self._node)
+
+    def get[T: BencodeWrap](self, t: type[T], index: int):
+        """Retrieve by index and typecheck"""
+
+        return wrap(t, self._node[index], f"{self._path}[{index}]")
+
     def cast[T: BencodeWrap](self, t: type[T]) -> Generator[T]:
+        """Enumerate all items while typechecking them."""
+
         for index, child_node in enumerate(self._node):
             yield wrap(t, child_node, f"{self._path}[{index}]")
 
 
 class BencodeDict:
+    """Wraps a bencode dict. Allows retrieving items by key."""
+
     def __init__(self, node: dict[bytes, BencodeType], path: str) -> None:
         self._node = node
         self._path = path
 
     @overload
-    def get[T: BencodeWrap](self, t: type[T], key: bytes) -> T: ...
+    def get[T: BencodeWrap](self, t: type[T], key: bytes) -> T:
+        """Retrieve an item by key. If the key is not present, raises ConversionError."""
+        ...
     @overload
     def get[T: BencodeWrap](
         self, t: type[T], key: bytes, *, default: BencodeType
-    ) -> T: ...
+    ) -> T:
+        """Retrieve an item by key. If the key is not present, returns the provided default."""
+        ...
     @overload
     def get[T: BencodeWrap](
         self, t: type[T], key: bytes, *, opt: Literal[True]
-    ) -> None | T: ...
+    ) -> None | T:
+        """Retrieve an item by key. If the key is not present, returns None."""
+        ...
     def get[T: BencodeWrap](
         self,
         t: type[T],
@@ -105,10 +129,12 @@ class BencodeDict:
         return wrap(t, child_node, child_path)
 
     def encode(self) -> bytes:
+        """Bencodes the wrapped data and returns the resulting string."""
         return encode(self._node)
 
     @staticmethod
     def decode(encoded: bytes, name: str) -> "BencodeDict":
+        """Decodes a bencoded string and wraps it in a new BencodeDict."""
         decoded = decode(encoded)
         return wrap(BencodeDict, decoded, name)
 

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -295,12 +295,16 @@ def is_piece_complete(
     first_byte_mask = FIRST_BYTE_MASK_BY_BIT_ORDER[piece_start_bit_order]
     last_byte_mask = LAST_BYTE_MASK_BY_BIT_ORDER[piece_end_bit_order]
     if num_piece_bytes == 1:
+        # If there is only one byte we mask as first and last byte
         byte_mask = first_byte_mask & last_byte_mask
         return piece_bytes[0] & byte_mask == byte_mask
     if piece_bytes[0] & first_byte_mask != first_byte_mask:
+        # If the piece fails the mask for the first byte
         return False
     if piece_bytes[-1] & last_byte_mask != last_byte_mask:
+        # If the piece fails the mask for the last byte
         return False
+    # Test all bytes except the first and the last (should all be 0xff)
     return piece_bytes[1:-1] == b"\xff" * (num_piece_bytes - 2)
 
 
@@ -344,13 +348,6 @@ def transmission_get_pieces(torrent: BencodeDict, resume: BencodeDict) -> bytes:
     if len(tr_blocks) > expected_block_bytes:
         raise ConversionError(
             f"the resume block length was expected to be {expected_block_bytes} but was {len(tr_blocks)}"
-        )
-    if len(tr_blocks) < expected_block_bytes:
-        # This happens on incomplete torrents, specifically when the last blocks are not on disk
-        # In these cases Transmission will not write the full blocks to the resume
-        # We can skip the check on all missing pieces
-        logging.warning(
-            f"incomplete torrent: the Transmission resume block has {len(tr_blocks)} bytes instead of {expected_block_bytes}, the qBittorrent pieces will be padded to size"
         )
 
     # Initialise the return object with 0s

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -210,8 +210,8 @@ def transmission_get_peers(resume: BencodeDict, key: bytes, addr_size: int) -> b
 
     if isinstance(src, bytes):
         return peers_convert_from_raw_bytes(src, addr_size)
-
-    return peers_convert_from_bencoded(resume, key)
+    else:
+        return peers_convert_from_bencoded(resume, key)
 
 
 def transmission_get_limit(resume: BencodeDict, limit_kind: str) -> int:

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -50,6 +50,12 @@ class BencodeListWrapper[T: bytes | int](Iterator[T]):
 
     def unwrap(self) -> BencodeList:
         return self._data
+    
+    def __getitem__(self, key: int) -> T:
+        item = self._data[key]
+        if not isinstance(item, self._item_type):
+            raise ConversionError(f"{self._path}[{key}] is not {T}")
+        return item
 
     def __len__(self) -> int:
         return len(self._data)
@@ -61,13 +67,13 @@ class BencodeListWrapper[T: bytes | int](Iterator[T]):
         self._index += 1
 
         try:
-            next_item = next(self._iter)
+            item = next(self._iter)
         except StopIteration:
             raise StopIteration
 
-        if not isinstance(next_item, self._item_type):
+        if not isinstance(item, self._item_type):
             raise ConversionError(f"{self._path}[{self._index}] is not {T}")
-        return next_item
+        return item
 
 
 class BencodeDictWrapper:

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -34,13 +34,15 @@ class QbtUsesSqliteForResumeError(RuntimeError):
     pass
 
 
-type BencodeType = bytes | int | list[BencodeType] | dict[bytes, BencodeType]
+type BencodeList = list["BencodeType"]
+type BencodeDict = dict[bytes, "BencodeType"]
+type BencodeType = bytes | int | BencodeList | dict[bytes, BencodeType]
 
 
 @dataclass(frozen=True)
 class BencodeData:
     path: str
-    data: dict[bytes, BencodeType]
+    data: BencodeDict
 
     def _get[T](
         self, key: bytes, type: type[T], optional: bool, default: T | None
@@ -80,14 +82,12 @@ class BencodeData:
     @overload
     def get_list(
         self, key: bytes, *, optional: Literal[False] = False
-    ) -> list[BencodeType]: ...
+    ) -> BencodeList: ...
     @overload
     def get_list(
         self, key: bytes, *, optional: Literal[True]
-    ) -> list[BencodeType] | None: ...
-    def get_list(
-        self, key: bytes, *, optional: bool = False
-    ) -> list[BencodeType] | None:
+    ) -> BencodeList | None: ...
+    def get_list(self, key: bytes, *, optional: bool = False) -> BencodeList | None:
         result = self.data.get(key)
         if result is None:
             if optional:
@@ -205,7 +205,7 @@ def peers_convert_from_raw_bytes(src: bytes, addr_size: int):
     return bytes(rv)
 
 
-def peers_convert_from_bencoded(src: list[BencodeType], key: bytes):
+def peers_convert_from_bencoded(src: BencodeList, key: bytes):
     # used since Transmission commit 1054ba4 (earliest release - 4.1.0)
     rv = bytearray()
     for i, d in enumerate(src):

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -58,7 +58,7 @@ class BencodeData:
         return cast(T, result)
 
     @overload
-    def get_bytes(self, key: bytes, *, optional: Literal[False] = False) -> bytes: ...
+    def get_bytes(self, key: bytes) -> bytes: ...
     @overload
     def get_bytes(self, key: bytes, *, optional: Literal[True]) -> bytes | None: ...
     @overload
@@ -69,7 +69,7 @@ class BencodeData:
         return self._get(key, bytes, optional, default)
 
     @overload
-    def get_int(self, key: bytes, *, optional: Literal[False] = False) -> int: ...
+    def get_int(self, key: bytes) -> int: ...
     @overload
     def get_int(self, key: bytes, *, optional: Literal[True]) -> int | None: ...
     @overload
@@ -80,9 +80,7 @@ class BencodeData:
         return self._get(key, int, optional, default)
 
     @overload
-    def get_list(
-        self, key: bytes, *, optional: Literal[False] = False
-    ) -> BencodeList: ...
+    def get_list(self, key: bytes) -> BencodeList: ...
     @overload
     def get_list(
         self, key: bytes, *, optional: Literal[True]
@@ -100,9 +98,7 @@ class BencodeData:
         return result
 
     @overload
-    def get_dict(
-        self, key: bytes, *, optional: Literal[False] = False
-    ) -> "BencodeData": ...
+    def get_dict(self, key: bytes) -> "BencodeData": ...
     @overload
     def get_dict(
         self, key: bytes, *, optional: Literal[True]

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -317,7 +317,7 @@ def map_resume_to_qbt(
     downloading_time_seconds, _ = get_child(resume, b"downloading-time-seconds", int)
     seeding_time_seconds, _ = get_child(resume, b"seeding-time-second", int)
     name, _ = get_child(resume, b"name", bytes)
-    paused, __ = get_child(resume, b"paused", int)
+    paused, _ = get_child(resume, b"paused", int)
 
     qbt_resume_data: BencodeType = {
         b"file-format": b"libtorrent resume file",

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
 from dataclasses import dataclass
-from typing import Literal, cast, overload
-from collections.abc import Generator, Iterator
+from typing import Literal, cast, get_origin, overload
+from collections.abc import Generator
 import sys
 import os
 import argparse
@@ -40,118 +40,53 @@ type BencodeDict = dict[bytes, "BencodeType"]
 type BencodeType = bytes | int | BencodeList | BencodeDict
 
 
-class BencodeListWrapper[T: bytes | int](Iterator[T]):
-    def __init__(self, item_type: type[T], path: str, data: BencodeList) -> None:
-        self._item_type = item_type
-        self._path = path
-        self._data = data
-        self._iter = iter(self._data)
-        self._index = -1
-
-    def unwrap(self) -> BencodeList:
-        return self._data
-
-    def __getitem__(self, key: int) -> T:
-        return self._safecast(self._data[key], key)
-
-    def __len__(self) -> int:
-        return len(self._data)
-
-    def __iter__(self) -> Iterator[T]:
-        return self
-
-    def __next__(self) -> T:
-        self._index += 1
-
-        try:
-            item = next(self._iter)
-        except StopIteration:
-            raise StopIteration
-
-        return self._safecast(item, self._index)
-
-    def _safecast(self, item: BencodeType, index: int) -> T:
-        if not isinstance(item, self._item_type):
-            raise ConversionError(f"{self._path}[{self._index}] is not {T}")
-        return item
+def safe_cast[T: BencodeType](
+    type_dest: type[T], error_path: str, value: BencodeType
+) -> T:
+    # origin is the parent class for generics (e.g. list for list[int])
+    # origin is none for non-generics
+    # isinstance does not work on generics but it works on the origin of a generic
+    # cast works on the generic itself so type inference works
+    typecheck = get_origin(type_dest) or type_dest
+    if not isinstance(value, typecheck):
+        raise ConversionError(f"f{error_path} is not of type {typecheck}")
+    return cast(T, value)
 
 
-class BencodeDictWrapper:
-    def __init__(self, path: str, data: BencodeDict) -> None:
-        self._path: str
-        self._data: BencodeDict
-
-    def unwrap(self) -> BencodeDict:
-        return self._data
-
-    @overload
-    def get[T: bytes | int](self, type: type[T], key: bytes) -> T: ...
-    @overload
-    def get[T: bytes | int](
-        self, type: type[T], key: bytes, *, optional: Literal[True]
-    ) -> T | None: ...
-    @overload
-    def get[T: bytes | int](self, type: type[T], key: bytes, *, default: T) -> T: ...
-    def get[T](
-        self,
-        type: type[T],
-        key: bytes,
-        *,
-        optional: bool = False,
-        default: T | None = None,
-    ) -> T | None:
-        result = self._data.get(key)
-        if result is None:
-            if optional or default is not None:
-                return default
-            raise ConversionError(f"{self._path}.{key.decode()} missing")
-
-        if not isinstance(result, type):
-            raise ConversionError(f"{self._path}.{key.decode()} is not {type}")
-
-        return result
-
-    @overload
-    def get_list[T: bytes | int](
-        self, item_type: type[T], key: bytes
-    ) -> BencodeListWrapper[T]: ...
-    @overload
-    def get_list[T: bytes | int](
-        self, item_type: type[T], key: bytes, *, optional: Literal[True]
-    ) -> BencodeListWrapper[T] | None: ...
-    def get_list[T: bytes | int](
-        self, item_type: type[T], key: bytes, *, optional: bool = False
-    ) -> BencodeListWrapper[T] | None:
-        data = self._data.get(key)
-        if data is None:
-            if optional:
-                return None
-            raise ConversionError(f"{self._path}.{key.decode()} is missing")
-
-        if not isinstance(data, list):
-            raise ConversionError(f"{self._path}.{key.decode()} is not a list")
-
-        return BencodeListWrapper(item_type, f"{self._path}.{key.decode()}", data)
-
-    @overload
-    def get_dict(self, key: bytes) -> "BencodeDictWrapper": ...
-    @overload
-    def get_dict(
-        self, key: bytes, *, optional: Literal[True]
-    ) -> "BencodeDictWrapper | None": ...
-    def get_dict(
-        self, key: bytes, *, optional: bool = False
-    ) -> "BencodeDictWrapper | None":
-        result = self._data.get(key)
-        if result is None:
-            if optional:
-                return None
-            raise ConversionError(f"{self._path}.{key.decode()} missing")
-
-        if not isinstance(result, dict):
-            raise ConversionError(f"{self._path}.{key.decode()} is not a dict")
-
-        return BencodeDictWrapper(f"{self._path}.{key.decode()}", result)
+@overload
+def get[T: BencodeType](
+    type_dest: type[T],
+    error_path: str,
+    data: BencodeDict,
+    key: bytes,
+    *,
+    default: T | None = None,
+) -> T: ...
+@overload
+def get[T: BencodeType](
+    type_dest: type[T],
+    error_path: str,
+    data: BencodeDict,
+    key: bytes,
+    *,
+    optional: Literal[True],
+) -> T | None: ...
+def get[T: BencodeType](
+    type_dest: type[T],
+    error_path: str,
+    data: BencodeDict,
+    key: bytes,
+    *,
+    default: T | None = None,
+    optional: bool = False,
+) -> T | None:
+    error_path = f"{error_path}.{key.decode()}"
+    value = data.get(key, default)
+    if value is None:
+        if optional:
+            return None
+        raise ConversionError(f"{error_path} is missing")
+    return safe_cast(type_dest, error_path, value)
 
 
 def bencode(data: BencodeType) -> bytes:
@@ -168,35 +103,35 @@ def check_for_qbt_sqlite_resume_db(qbt_bt_backup_dir: str) -> None:
         raise QbtUsesSqliteForResumeError()
 
 
-def get_data(root: str, path: str) -> BencodeDictWrapper:
+def get_data(error_path: str, path: str) -> BencodeDict:
     with open(path, "rb") as f:
         try:
             decoded = bdecode(f.read())
         except (ValueError, bencodepy.BencodeDecodeError) as e:
             raise ReadBencodedError(path) from e
-    if not isinstance(decoded, dict):
-        raise ConversionError(f"{root} is not a dict")
-    return BencodeDictWrapper(root, decoded)
+    return safe_cast(dict[bytes, BencodeType], error_path, decoded)
 
 
 # FIXME BEP0003 says that clients must not perform a decode-encode
 # roundtrip on invalid data. this is exactly what this does.
-def calc_info_hash(parsed_tor: BencodeDictWrapper) -> str:
-    info = parsed_tor.get_dict(b"info")
-    return hashlib.sha1(bencode(info.unwrap())).hexdigest()
+def calc_info_hash(parsed_tor: BencodeDict) -> str:
+    info = get(dict[bytes, BencodeType], "torrent", parsed_tor, b"info")
+    return hashlib.sha1(bencode(info)).hexdigest()
 
 
-def transmission_get_speed_limit(resume_data: BencodeDictWrapper, key: bytes) -> int:
-    speed_limit_obj = resume_data.get_dict(key)
-    if speed_limit_obj.get(int, b"use-speed-limit") != 0:
-        return speed_limit_obj.get(int, b"speed-Bps")
+def transmission_get_speed_limit(resume_data: BencodeDict, key: bytes) -> int:
+    speed_limit_obj = get(dict[bytes, BencodeType], "resume", resume_data, key)
+    speed_limit_path = f"resume.{key.decode()}"
+    use_speed_limit = get(int, speed_limit_path, speed_limit_obj, b"use-speed-limit")
+    if use_speed_limit != 0:
+        return get(int, speed_limit_path, speed_limit_obj, b"speed-Bps")
 
     return -1
 
 
-def transmission_get_file_prorities(resume_data: BencodeDictWrapper) -> Generator[int]:
-    priority = resume_data.get_list(int, b"priority", optional=True)
-    dnd = resume_data.get_list(int, b"dnd", optional=True)
+def transmission_get_file_prorities(resume_data: BencodeDict) -> Generator[int]:
+    priority = get(list[BencodeType], "resume", resume_data, b"priority", optional=True)
+    dnd = get(list[BencodeType], "resume", resume_data, b"dnd", optional=True)
 
     # Return empty list if priority data is not available
     if priority is None or dnd is None:
@@ -239,19 +174,17 @@ def peers_convert_from_bencoded(src: BencodeList, key: bytes) -> bytes:
     # used since Transmission commit 1054ba4 (earliest release - 4.1.0)
     rv = bytearray()
     for i, d in enumerate(src):
-        if not isinstance(d, dict):
-            raise ConversionError(f"{key}[{i}] is not a dict")
-        socket_address = d[b"socket_address"]
-        if not isinstance(socket_address, bytes):
-            raise ConversionError(f"{key}[{i}].socket_address is not a bytes")
+        d_path = f"{key}[{i}]"
+        d_dict = safe_cast(dict[bytes, BencodeType], d_path, d)
+        socket_address = get(bytes, d_path, d_dict, b"socket_address")
         rv += socket_address
     return bytes(rv)
 
 
 def transmission_get_peers(
-    resume_data: BencodeDictWrapper, addr_size: int, key: bytes
+    resume_data: BencodeDict, addr_size: int, key: bytes
 ) -> bytes:
-    src = resume_data.unwrap().get(key)
+    src = resume_data.get(key)
     if src is None:
         return b""
 
@@ -261,21 +194,22 @@ def transmission_get_peers(
     if isinstance(src, bytes):
         return peers_convert_from_raw_bytes(src, addr_size)
 
-    raise ConversionError(f"{key} is not a list or a bytes")
+    raise ConversionError(f"{key} is not a list or bytes")
 
 
-def transmission_get_limit(tr_resume: BencodeDictWrapper, limit_kind: str) -> int:
+def transmission_get_limit(tr_resume: BencodeDict, limit_kind: str) -> int:
     limit_key = f"{limit_kind}-limit".encode()
-    mode_key = f"{limit_kind}-mode".encode()
+    limit_obj = get(dict[bytes, BencodeType], "resume", tr_resume, limit_key)
 
-    limit_obj = tr_resume.get_dict(limit_key)
-    limit_mode = limit_obj.get(int, mode_key)
+    mode_key = f"{limit_kind}-mode".encode()
+    limit_path = f"resume.{limit_key}"
+    limit_mode = get(int, limit_path, limit_obj, mode_key)
 
     match limit_mode:
         case 0:  # TR_*LIMIT_GLOBAL
             return -2  # BitTorrent::Torrent::USE_GLOBAL_*
         case 1:  # TR_*LIMIT_SINGLE
-            return limit_obj.get(int, limit_key)
+            return get(int, limit_path, limit_obj, limit_key)
         case 2:  # TR_*LIMIT_UNLIMITED
             return -1  # BitTorrent::Torrent::NO_*_LIMIT
         case _:
@@ -314,12 +248,10 @@ def get_last_piece_mask_for_block_checking(torrent_size: int, piece_size: int) -
     return piece_mask
 
 
-def transmission_get_pieces(
-    parsed_tor: BencodeDictWrapper, tr_resume: BencodeDictWrapper
-) -> bytes:
-    info = parsed_tor.get_dict(b"info")
-    torrent_size = info.get(int, b"length")
-    piece_size = info.get(int, b"piece length")
+def transmission_get_pieces(parsed_tor: BencodeDict, tr_resume: BencodeDict) -> bytes:
+    info = get(dict[bytes, BencodeType], "torrent", parsed_tor, b"info")
+    torrent_size = get(int, "torrent.info", info, b"length")
+    piece_size = get(int, "torrent.info", info, b"piece length")
 
     # Sanity check the piece length
     # Only accept piece size in powers of 2
@@ -335,7 +267,8 @@ def transmission_get_pieces(
     if piece_size < 1 << 17:  # 128KiB
         raise ConversionError(f"Piece size {piece_size} is lower than 128KiB, aborting")
 
-    blocks = tr_resume.get_dict(b"progress").get(bytes, b"blocks")
+    progress = get(dict[bytes, BencodeType], "resume", tr_resume, b"progress")
+    blocks = get(bytes, "resume.progress", progress, b"blocks")
 
     # Sanity check the block bytes length
     # ceiling integer division
@@ -376,34 +309,39 @@ def transmission_get_pieces(
 
 
 def map_resume_to_qbt(
-    info_hash: str, parsed_tor: BencodeDictWrapper, resume_data: BencodeDictWrapper
+    info_hash: str, parsed_tor: BencodeDict, resume_data: BencodeDict
 ) -> BencodeDict:
-    downloading_time_seconds = resume_data.get(int, b"downloading-time-seconds")
-    seeding_time_seconds = resume_data.get(int, b"seeding-time-seconds")
-    name = resume_data.get(bytes, b"name")
+    downloading_time_seconds = get(
+        int, "resume", resume_data, b"downloading-time-seconds"
+    )
+    seeding_time_seconds = get(int, "resume", resume_data, b"seeding-time-second")
+    name = get(bytes, "resume", resume_data, b"name")
+    paused = get(int, "resume", resume_data, b"paused")
 
     qbt_resume_data: BencodeType = {
         b"file-format": b"libtorrent resume file",
         b"file-version": 1,
         b"info-hash": binascii.unhexlify(info_hash),
         b"name": name,
-        b"total_uploaded": resume_data.get(int, b"uploaded"),
-        b"total_downloaded": resume_data.get(int, b"downloaded"),
-        b"added_time": resume_data.get(int, b"added-date"),
-        b"completed_time": resume_data.get(int, b"done-date"),
+        b"total_uploaded": get(int, "resume", resume_data, b"uploaded"),
+        b"total_downloaded": get(int, "resume", resume_data, b"downloaded"),
+        b"added_time": get(int, "resume", resume_data, b"added-date"),
+        b"completed_time": get(int, "resume", resume_data, b"done-date"),
         b"active_time": downloading_time_seconds + seeding_time_seconds,
         b"finished_time": downloading_time_seconds,
         b"seeding_time": seeding_time_seconds,
-        b"max_connections": resume_data.get(int, b"max-peers"),
+        b"max_connections": get(int, "resume", resume_data, b"max-peers"),
         b"upload_rate_limit": transmission_get_speed_limit(
             resume_data, b"speed-limit-up"
         ),
         b"download_rate_limit": transmission_get_speed_limit(
             resume_data, b"speed-limit-down"
         ),
-        b"save_path": resume_data.get(bytes, b"destination"),
-        b"paused": resume_data.get(int, b"paused"),
-        b"sequential_download": resume_data.get(int, b"sequentialDownload", default=0),
+        b"save_path": get(bytes, "resume", resume_data, b"destination"),
+        b"paused": paused,
+        b"sequential_download": get(
+            int, "resume", resume_data, b"sequentialDownload", default=0
+        ),
         b"file_priority": list(transmission_get_file_prorities(resume_data)),
         b"peers": transmission_get_peers(resume_data, 4, b"peers2"),
         b"peers6": transmission_get_peers(resume_data, 16, b"peers2-6"),
@@ -412,27 +350,26 @@ def map_resume_to_qbt(
         b"qBt-inactiveSeedingTimeLimit": int(
             transmission_get_limit(resume_data, "idle")
         ),
-        b"qBt-savePath": resume_data.get(bytes, b"destination"),
+        b"qBt-savePath": get(bytes, "resume", resume_data, b"destination"),
         b"pieces": transmission_get_pieces(parsed_tor, resume_data),
     }
 
-    group = resume_data.get(bytes, b"group", optional=True)
+    group = get(bytes, "resume", resume_data, b"group", optional=True)
     if group is not None:
         qbt_resume_data[b"qBt-category"] = group
 
-    labels = resume_data.get_list(bytes, b"labels", optional=True)
+    labels = get(list[BencodeType], "resume", resume_data, b"labels", optional=True)
     if labels is not None:
-        qbt_resume_data[b"qBt-tags"] = labels.unwrap()
+        qbt_resume_data[b"qBt-tags"] = labels
 
-    files = resume_data.get_list(bytes, b"files", optional=True)
+    files = get(list[BencodeType], "resume", resume_data, b"files", optional=True)
     if files is not None:
-        qbt_resume_data[b"mapped_files"] = files.unwrap()
+        qbt_resume_data[b"mapped_files"] = files
 
-    incomplete_dir = resume_data.get(bytes, b"incomplete_dir", optional=True)
+    incomplete_dir = get(bytes, "resume", resume_data, b"incomplete_dir", optional=True)
     if incomplete_dir is not None:
         qbt_resume_data[b"qBt-downloadPath"] = incomplete_dir
 
-    paused = resume_data.get(int, b"paused")
     if paused == 1:
         qbt_resume_data[b"auto_managed"] = 0
 
@@ -462,8 +399,8 @@ class TransmissionQbtImporter:
         self,
         source_tor_abs_path: str,
         info_hash: str,
-        parsed_tor: BencodeDictWrapper,
-        resume_data: BencodeDictWrapper,
+        parsed_tor: BencodeDict,
+        resume_data: BencodeDict,
     ) -> None:
         qbt_resume_data = map_resume_to_qbt(info_hash, parsed_tor, resume_data)
         qbt_resume_path = os.path.join(self.target_dir, info_hash + ".fastresume")

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -109,7 +109,7 @@ def check_for_qbt_sqlite_resume_db(qbt_bt_backup_dir: str) -> None:
         raise QbtUsesSqliteForResumeError()
 
 
-def get_data(file_path: str, node_path: str) -> BencodeDict:
+def read_bencoded(file_path: str, node_path: str) -> BencodeDict:
     with open(file_path, "rb") as f:
         try:
             decoded = bdecode(f.read())
@@ -424,9 +424,9 @@ class TransmissionQbtImporter:
         source_res_abs_path: str,
         info_hash: str | None,
     ) -> None:
-        torrent = get_data(source_tor_abs_path, "torrent")
+        torrent = read_bencoded(source_tor_abs_path, "torrent")
 
-        resume = get_data(source_res_abs_path, "resume")
+        resume = read_bencoded(source_res_abs_path, "resume")
 
         if info_hash is None:
             info_hash = calc_info_hash(torrent)

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -81,59 +81,51 @@ class BencodeDict:
         self._path = path
 
     @overload
-    def get[T: bytes | int](self, t: type[T], child_name: bytes) -> T: ...
+    def get[T: bytes | int](self, t: type[T], key: bytes) -> T: ...
+    @overload
+    def get[T: bytes | int](self, t: type[T], key: bytes, *, default: T) -> T: ...
     @overload
     def get[T: bytes | int](
-        self, t: type[T], child_name: bytes, *, default: T
-    ) -> T: ...
-    @overload
-    def get[T: bytes | int](
-        self, t: type[T], child_name: bytes, *, optional: Literal[True]
+        self, t: type[T], key: bytes, *, opt: Literal[True]
     ) -> None | T: ...
     def get[T: bytes | int](
         self,
         t: type[T],
-        child_name: bytes,
+        key: bytes,
         *,
         default: T | None = None,
-        optional: bool = False,
+        opt: bool = False,
     ) -> None | T:
-        child = self._get_child(child_name, default, optional)
+        child = self._get_child(key, default, opt)
         if child is None:
             return None
         return convert(t, *child)
 
     @overload
-    def get_list(self, child_name: bytes) -> BencodeList: ...
+    def get_list(self, key: bytes) -> BencodeList: ...
     @overload
-    def get_list(
-        self, child_name: bytes, *, optional: Literal[True]
-    ) -> None | BencodeList: ...
-    def get_list(
-        self, child_name: bytes, *, optional: bool = False
-    ) -> None | BencodeList:
-        child = self._get_child(child_name, None, optional)
+    def get_list(self, key: bytes, *, opt: Literal[True]) -> None | BencodeList: ...
+    def get_list(self, key: bytes, *, opt: bool = False) -> None | BencodeList:
+        child = self._get_child(key, None, opt)
         if child is None:
             return None
         return BencodeList(*child)
 
     @overload
-    def get_dict(self, name: bytes) -> "BencodeDict": ...
+    def get_dict(self, key: bytes) -> "BencodeDict": ...
     @overload
-    def get_dict(
-        self, name: bytes, *, optional: Literal[True]
-    ) -> "None | BencodeDict": ...
-    def get_dict(self, name: bytes, *, optional: bool = False) -> "None | BencodeDict":
-        child = self._get_child(name, None, optional)
+    def get_dict(self, key: bytes, *, opt: Literal[True]) -> "None | BencodeDict": ...
+    def get_dict(self, key: bytes, *, opt: bool = False) -> "None | BencodeDict":
+        child = self._get_child(key, None, opt)
         if child is None:
             return None
         return BencodeDict(*child)
 
-    def _get_child(self, name: bytes, default: BencodeType | None, optional: bool):
-        child_node = self._node.get(name, default)
-        child_path = f"{self._path}.{name.decode()}"
+    def _get_child(self, key: bytes, default: BencodeType | None, opt: bool):
+        child_node = self._node.get(key, default)
+        child_path = f"{self._path}.{key.decode()}"
         if child_node is None:
-            if optional:
+            if opt:
                 return None
             raise ConversionError(f"{child_path} is missing")
         return child_node, child_path
@@ -177,8 +169,8 @@ def transmission_get_speed_limit(resume: BencodeDict, key: bytes) -> int:
 
 
 def transmission_get_file_priorities(resume: BencodeDict) -> Generator[int]:
-    priority = resume.get_list(b"priority", optional=True)
-    dnd = resume.get_list(b"dnd", optional=True)
+    priority = resume.get_list(b"priority", opt=True)
+    dnd = resume.get_list(b"dnd", opt=True)
 
     # Return empty list if priority data is not available
     if priority is None or dnd is None:
@@ -202,7 +194,7 @@ def transmission_get_file_priorities(resume: BencodeDict) -> Generator[int]:
 def peers_convert_from_raw_bytes(
     resume: BencodeDict, key: bytes, addr_size: int
 ) -> bytes:
-    peers = resume.get(bytes, key, optional=True)
+    peers = resume.get(bytes, key, opt=True)
     if peers is None:
         return b""
 
@@ -219,7 +211,7 @@ def peers_convert_from_raw_bytes(
 
 
 def peers_convert_from_bencoded(resume: BencodeDict, key: bytes) -> bytes:
-    peers = resume.get_list(key, optional=True)
+    peers = resume.get_list(key, opt=True)
     if peers is None:
         return b""
     return b"".join(d.get(bytes, b"socket_address") for d in peers.get_dicts())
@@ -345,7 +337,7 @@ def is_piece_complete(
 
 def transmission_get_pieces(torrent: BencodeDict, resume: BencodeDict) -> bytes:
     torrent_info = torrent.get_dict(b"info")
-    torrent_size = torrent_info.get(int, b"length", optional=True) or sum(
+    torrent_size = torrent_info.get(int, b"length", opt=True) or sum(
         file.get(int, b"length") for file in torrent_info.get_list(b"files").get_dicts()
     )
     piece_size = torrent_info.get(int, b"piece length")
@@ -392,13 +384,13 @@ def transmission_get_pieces(torrent: BencodeDict, resume: BencodeDict) -> bytes:
 def transmission_get_files(
     torrent_info: BencodeDict, resume: BencodeDict
 ) -> None | list[BencodeType]:
-    resume_files = resume.get_list(b"files", optional=True)
+    resume_files = resume.get_list(b"files", opt=True)
     if resume_files is None:
         return None
     actual_files: list[BencodeType] = list(resume_files.get(bytes))
 
     torrent_name = torrent_info.get(bytes, b"name")
-    torrent_files = torrent_info.get_list(b"files", optional=True)
+    torrent_files = torrent_info.get_list(b"files", opt=True)
     if torrent_files is None:
         # Single-file torrent
         expected_files = [torrent_name]
@@ -457,11 +449,11 @@ def map_resume_to_qbt(
         qbt_resume_data[b"peers"] = transmission_get_peers(resume, b"peers2", 4)
         qbt_resume_data[b"peers6"] = transmission_get_peers(resume, b"peers2-6", 16)
 
-    group = resume.get(bytes, b"group", optional=True)
+    group = resume.get(bytes, b"group", opt=True)
     if group is not None:
         qbt_resume_data[b"qBt-category"] = group
 
-    labels = resume.get_list(b"labels", optional=True)
+    labels = resume.get_list(b"labels", opt=True)
     if labels is not None:
         qbt_resume_data[b"qBt-tags"] = list(labels.get(bytes))
 
@@ -476,7 +468,7 @@ def map_resume_to_qbt(
     if files is not None:
         qbt_resume_data[b"mapped_files"] = files
 
-    incomplete_dir = resume.get(bytes, b"incomplete_dir", optional=True)
+    incomplete_dir = resume.get(bytes, b"incomplete_dir", opt=True)
     if incomplete_dir is not None:
         qbt_resume_data[b"qBt-downloadPath"] = incomplete_dir
 

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -37,25 +37,25 @@ class QbtUsesSqliteForResumeError(RuntimeError):
 
 
 type BencodeType = bytes | int | list[BencodeType] | dict[bytes, BencodeType]
-"""A helper alias for the types that bencode data nodes can represent."""
+"""A helper alias for the types that bencode data nodes can be represented as."""
 
 type BencodeWrap = bytes | int | BencodeList | BencodeDict
 """A helper alias for the wrapper types associated with bencode types."""
 
 
 def encode(data: BencodeType) -> bytes:
-    """Wraps the bencode.py encode function to avoid typechecking errors."""
+    """Wraps the bencode.py encode function to avoid code analysis errors."""
     return bencodepy.encode(data)  # type: ignore
 
 
 def decode(data: bytes) -> BencodeType:
-    """Wraps the bencode.py decode function to avoid typechecking errors."""
+    """Wraps the bencode.py decode function to avoid code analysis errors."""
     return bencodepy.decode(data)  # type: ignore
 
 
 def wrap[T: BencodeWrap](t: type[T], node: BencodeType, path: str) -> T:
     """Wraps a bencode type.
-    dicts and lists are typechecked and wrapped in BencodeList and BencodeDict respectively.
+    dicts & lists are typechecked and wrapped in BencodeList and BencodeDict respectively.
     Scalar types (bytes & int) are typechecked and returned as is."""
 
     if t is BencodeList:
@@ -81,8 +81,8 @@ class BencodeList:
     def __len__(self):
         return len(self._node)
 
-    def get[T: BencodeWrap](self, t: type[T], index: int):
-        """Retrieve by index and typecheck"""
+    def get[T: BencodeWrap](self, t: type[T], index: int) -> T:
+        """Retrieve by index and typecheck."""
 
         return wrap(t, self._node[index], f"{self._path}[{index}]")
 
@@ -173,19 +173,40 @@ def transmission_get_speed_limit(resume: BencodeDict, key: bytes) -> int:
     return -1
 
 
-def transmission_get_file_priorities(resume: BencodeDict) -> Generator[int]:
-    priority = resume.get(BencodeList, b"priority", optional=True)
-    dnd = resume.get(BencodeList, b"dnd", optional=True)
+def transmission_get_file_priorities(
+    torrent_info: BencodeDict, resume: BencodeDict
+) -> Generator[int]:
+    priorities = resume.get(BencodeList, b"priority", optional=True)
+    dnds = resume.get(BencodeList, b"dnd", optional=True)
 
     # Return empty list if priority data is not available
-    if priority is None or dnd is None:
+    if priorities is None or dnds is None:
         return
 
-    for i, (p, d) in enumerate(zip(priority.cast(int), dnd.cast(int), strict=True)):
-        if d == 1:
+    if len(priorities) != len(dnds):
+        raise ConversionError(
+            f"priority and dnd lengths are not equal : {len(priorities)} != {len(dnds)}"
+        )
+
+    files = torrent_info.get(BencodeList, b"files", optional=True)
+    if files is None:
+        file_sizes = [torrent_info.get(int, b"length")]
+    else:
+        file_sizes = [file.get(int, b"length") for file in files.cast(BencodeDict)]
+
+    index = 0
+    for file_size in file_sizes:
+        if file_size == 0:
+            # Transmission ignores 0-sized files entirely including when building the priority & dnd lists,
+            # but qBittorrent does not. This creates a mismatch in the index between the two resume files,
+            # meaning we have to explicitly return an extra item here, while NOT incrementing the index.
+            yield 4  # libtorrent::default_priority
+            continue
+        if dnds.get(int, index) == 1:
             yield 0  # libtorrent::dont_download
         else:
-            match p:
+            priority = priorities.get(int, index)
+            match priority:
                 case -1:  # TR_PRI_LOW
                     yield 1  # libtorrent::low_priority
                 case 0:  # TR_PRI_NORMAL
@@ -193,7 +214,8 @@ def transmission_get_file_priorities(resume: BencodeDict) -> Generator[int]:
                 case 1:  # TR_PRI_HIGH
                     yield 7  # libtorrent::top_priority
                 case _:
-                    raise ConversionError(f"Unknown priority[{i}]: {p}")
+                    raise ConversionError(f"Unknown priority[{index}]: {priority}")
+        index += 1
 
 
 def peers_convert_from_raw_bytes(
@@ -387,9 +409,46 @@ def transmission_get_pieces(torrent: BencodeDict, resume: BencodeDict) -> bytes:
     return bytes(qb_pieces)
 
 
+def transmission_get_files(
+    torrent_info: BencodeDict, resume: BencodeDict
+) -> None | list[BencodeType]:
+    # Files as defined in the torrent
+    tor_files = torrent_info.get(BencodeList, b"files", optional=True)
+
+    # Files as defined in the Transmission resume
+    tr_name = resume.get(bytes, b"name")
+    tr_files = resume.get(BencodeList, b"files", optional=True)
+
+    if tor_files is None or tr_files is None:
+        # Single-file torrent
+        return None
+
+    # Files as defined in the qBittorrent resume
+    qbit_files = list[BencodeType]()
+
+    tr_index = 0
+    for tor_file in tor_files.cast(BencodeDict):
+        file_size = tor_file.get(int, b"length")
+        if file_size == 0:
+            # Transmission ignores 0-sized files entirely including when building the file list, but
+            # qBittorrent does not. This creates a mismatch in the index between the two resume files,
+            # meaning we have to explicitly return an extra item here, while NOT incrementing the index.
+            qbit_files.append(
+                tr_name
+                + b"/"
+                + b"/".join(tor_file.get(BencodeList, b"path").cast(bytes))
+            )
+        else:
+            qbit_files.append(tr_files.get(bytes, tr_index))
+            tr_index += 1
+
+    return qbit_files
+
+
 def map_resume_to_qbt(
     info_hash: str, torrent: BencodeDict, resume: BencodeDict, add_paused: bool
 ) -> dict[bytes, BencodeType]:
+    torrent_info = torrent.get(BencodeDict, b"info")
     downloading_time_seconds = resume.get(int, b"downloading-time-seconds")
     seeding_time_seconds = resume.get(int, b"seeding-time-seconds")
     name = resume.get(bytes, b"name")
@@ -415,15 +474,13 @@ def map_resume_to_qbt(
         b"save_path": resume.get(bytes, b"destination"),
         b"paused": paused,
         b"sequential_download": resume.get(int, b"sequentialDownload", default=0),
-        b"file_priority": list(transmission_get_file_priorities(resume)),
+        b"file_priority": list(transmission_get_file_priorities(torrent_info, resume)),
         b"qBt-name": name,
         b"qBt-ratioLimit": transmission_get_limit(resume, "ratio"),
         b"qBt-inactiveSeedingTimeLimit": int(transmission_get_limit(resume, "idle")),
         b"qBt-savePath": resume.get(bytes, b"destination"),
         b"pieces": transmission_get_pieces(torrent, resume),
     }
-
-    torrent_info = torrent.get(BencodeDict, b"info")
 
     if not torrent_info.get(int, b"private", default=0):
         qbt_resume_data[b"peers"] = transmission_get_peers(resume, b"peers2", 4)
@@ -437,9 +494,9 @@ def map_resume_to_qbt(
     if labels is not None:
         qbt_resume_data[b"qBt-tags"] = list(labels.cast(bytes))
 
-    files = resume.get(BencodeList, b"files", optional=True)
+    files = transmission_get_files(torrent_info, resume)
     if files is not None:
-        qbt_resume_data[b"mapped_files"] = list(files.cast(bytes))
+        qbt_resume_data[b"mapped_files"] = files
 
     incomplete_dir = resume.get(bytes, b"incomplete_dir", optional=True)
     if incomplete_dir is not None:

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -44,8 +44,21 @@ class BencodeData:
     path: str
     data: BencodeDict
 
-    def _get[T](
-        self, key: bytes, type: type[T], optional: bool, default: T | None
+    @overload
+    def get[T: bytes | int](self, type: type[T], key: bytes) -> T: ...
+    @overload
+    def get[T: bytes | int](
+        self, type: type[T], key: bytes, *, optional: Literal[True]
+    ) -> T | None: ...
+    @overload
+    def get[T: bytes | int](self, type: type[T], key: bytes, *, default: T) -> T: ...
+    def get[T: bytes | int](
+        self,
+        type: type[T],
+        key: bytes,
+        *,
+        optional: bool = False,
+        default: T | None = None,
     ) -> T | None:
         result = self.data.get(key)
         if result is None:
@@ -55,29 +68,8 @@ class BencodeData:
 
         if not isinstance(result, type):
             raise ConversionError(f"{self.path}.{key.decode()} is not {type}")
-        return cast(T, result)
 
-    @overload
-    def get_bytes(self, key: bytes) -> bytes: ...
-    @overload
-    def get_bytes(self, key: bytes, *, optional: Literal[True]) -> bytes | None: ...
-    @overload
-    def get_bytes(self, key: bytes, *, default: bytes) -> bytes: ...
-    def get_bytes(
-        self, key: bytes, *, optional: bool = False, default: bytes | None = None
-    ) -> bytes | None:
-        return self._get(key, bytes, optional, default)
-
-    @overload
-    def get_int(self, key: bytes) -> int: ...
-    @overload
-    def get_int(self, key: bytes, *, optional: Literal[True]) -> int | None: ...
-    @overload
-    def get_int(self, key: bytes, *, default: int) -> int: ...
-    def get_int(
-        self, key: bytes, *, optional: bool = False, default: int | None = None
-    ) -> int | None:
-        return self._get(key, int, optional, default)
+        return result
 
     @overload
     def get_list(self, key: bytes) -> BencodeList: ...
@@ -150,8 +142,8 @@ def calc_info_hash(parsed_tor: BencodeData):
 
 def transmission_get_speed_limit(resume_data: BencodeData, key: bytes):
     speed_limit_obj = resume_data.get_dict(key)
-    if speed_limit_obj.get_int(b"use-speed-limit") != 0:
-        return speed_limit_obj.get_int(b"speed-Bps")
+    if speed_limit_obj.get(int, b"use-speed-limit") != 0:
+        return speed_limit_obj.get(int, b"speed-Bps")
 
     return -1
 
@@ -233,13 +225,13 @@ def transmission_get_limit(tr_resume: BencodeData, limit_kind: str):
     mode_key = f"{limit_kind}-mode".encode()
 
     limit_obj = tr_resume.get_dict(limit_key)
-    limit_mode = limit_obj.get_int(mode_key)
+    limit_mode = limit_obj.get(int, mode_key)
 
     match limit_mode:
         case 0:  # TR_*LIMIT_GLOBAL
             return -2  # BitTorrent::Torrent::USE_GLOBAL_*
         case 1:  # TR_*LIMIT_SINGLE
-            return limit_obj.get_int(limit_key)
+            return limit_obj.get(int, limit_key)
         case 2:  # TR_*LIMIT_UNLIMITED
             return -1  # BitTorrent::Torrent::NO_*_LIMIT
         case _:
@@ -280,8 +272,8 @@ def get_last_piece_mask_for_block_checking(torrent_size: int, piece_size: int):
 
 def transmission_get_pieces(parsed_tor: BencodeData, tr_resume: BencodeData):
     info = parsed_tor.get_dict(b"info")
-    torrent_size = info.get_int(b"length")
-    piece_size = info.get_int(b"piece length")
+    torrent_size = info.get(int, b"length")
+    piece_size = info.get(int, b"piece length")
 
     # Sanity check the piece length
     # Only accept piece size in powers of 2
@@ -297,7 +289,7 @@ def transmission_get_pieces(parsed_tor: BencodeData, tr_resume: BencodeData):
     if piece_size < 1 << 17:  # 128KiB
         raise ConversionError(f"Piece size {piece_size} is lower than 128KiB, aborting")
 
-    blocks = tr_resume.get_dict(b"progress").get_bytes(b"blocks")
+    blocks = tr_resume.get_dict(b"progress").get(bytes, b"blocks")
 
     # Sanity check the block bytes length
     # ceiling integer division
@@ -340,32 +332,32 @@ def transmission_get_pieces(parsed_tor: BencodeData, tr_resume: BencodeData):
 def map_resume_to_qbt(
     info_hash: str, parsed_tor: BencodeData, resume_data: BencodeData
 ):
-    downloading_time_seconds = resume_data.get_int(b"downloading-time-seconds")
-    seeding_time_seconds = resume_data.get_int(b"seeding-time-seconds")
-    name = resume_data.get_bytes(b"name")
+    downloading_time_seconds = resume_data.get(int, b"downloading-time-seconds")
+    seeding_time_seconds = resume_data.get(int, b"seeding-time-seconds")
+    name = resume_data.get(bytes, b"name")
 
     qbt_resume_data: BencodeType = {
         b"file-format": b"libtorrent resume file",
         b"file-version": 1,
         b"info-hash": binascii.unhexlify(info_hash),
         b"name": name,
-        b"total_uploaded": resume_data.get_int(b"uploaded"),
-        b"total_downloaded": resume_data.get_int(b"downloaded"),
-        b"added_time": resume_data.get_int(b"added-date"),
-        b"completed_time": resume_data.get_int(b"done-date"),
+        b"total_uploaded": resume_data.get(int, b"uploaded"),
+        b"total_downloaded": resume_data.get(int, b"downloaded"),
+        b"added_time": resume_data.get(int, b"added-date"),
+        b"completed_time": resume_data.get(int, b"done-date"),
         b"active_time": downloading_time_seconds + seeding_time_seconds,
         b"finished_time": downloading_time_seconds,
         b"seeding_time": seeding_time_seconds,
-        b"max_connections": resume_data.get_int(b"max-peers"),
+        b"max_connections": resume_data.get(int, b"max-peers"),
         b"upload_rate_limit": transmission_get_speed_limit(
             resume_data, b"speed-limit-up"
         ),
         b"download_rate_limit": transmission_get_speed_limit(
             resume_data, b"speed-limit-down"
         ),
-        b"save_path": resume_data.get_bytes(b"destination"),
-        b"paused": resume_data.get_int(b"paused"),
-        b"sequential_download": resume_data.get_int(b"sequentialDownload", default=0),
+        b"save_path": resume_data.get(bytes, b"destination"),
+        b"paused": resume_data.get(int, b"paused"),
+        b"sequential_download": resume_data.get(int, b"sequentialDownload", default=0),
         b"file_priority": list(transmission_get_file_prorities(resume_data)),
         b"peers": transmission_get_peers(resume_data, 4, b"peers2"),
         b"peers6": transmission_get_peers(resume_data, 16, b"peers2-6"),
@@ -374,11 +366,11 @@ def map_resume_to_qbt(
         b"qBt-inactiveSeedingTimeLimit": int(
             transmission_get_limit(resume_data, "idle")
         ),
-        b"qBt-savePath": resume_data.get_bytes(b"destination"),
+        b"qBt-savePath": resume_data.get(bytes, b"destination"),
         b"pieces": transmission_get_pieces(parsed_tor, resume_data),
     }
 
-    group = resume_data.get_bytes(b"group", optional=True)
+    group = resume_data.get(bytes, b"group", optional=True)
     if group is not None:
         qbt_resume_data[b"qBt-category"] = group
 
@@ -390,11 +382,11 @@ def map_resume_to_qbt(
     if files is not None:
         qbt_resume_data[b"mapped_files"] = files
 
-    incomplete_dir = resume_data.get_bytes(b"incomplete_dir", optional=True)
+    incomplete_dir = resume_data.get(bytes, b"incomplete_dir", optional=True)
     if incomplete_dir is not None:
         qbt_resume_data[b"qBt-downloadPath"] = incomplete_dir
 
-    paused = resume_data.get_int(b"paused")
+    paused = resume_data.get(int, b"paused")
     if paused == 1:
         qbt_resume_data[b"auto_managed"] = 0
 

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -503,7 +503,7 @@ class TransmissionQbtImporter:
                 )
                 return
 
-        if predicate_rv is True:
+        if predicate_rv:
             self.copy_to_target(source_tor_abs_path, info_hash, torrent, resume)
         else:
             logging.info(

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from dataclasses import dataclass
-from typing import Literal, NamedTuple, cast, get_origin, overload
+from typing import Literal, cast, overload
 from collections.abc import Generator
 import sys
 import os
@@ -39,84 +39,112 @@ class QbtUsesSqliteForResumeError(RuntimeError):
 type BencodeType = bytes | int | list[BencodeType] | dict[bytes, BencodeType]
 
 
-class BencodeNode[T: BencodeType](NamedTuple):
-    # A class for convenience, which carries the full path of the node
-    # e.g. value=xxx, path="torrent.info.length"
-    value: T
-    path: str
+def encode(data: BencodeType) -> bytes:
+    return bencodepy.encode(data)  # type: ignore
 
 
-type BencodeDict = BencodeNode[dict[bytes, BencodeType]]
+def decode(data: bytes) -> BencodeType:
+    return bencodepy.decode(data)  # type: ignore
 
 
-def build_node[T: BencodeType](
-    value: BencodeType, type: type[T], path: str
-) -> BencodeNode[T]:
-    # origin is the parent class for generics (e.g. list for list[int])
-    # origin is none for non-generics
-    # isinstance does not work on generics but it works on the origin of a generic
-    # cast works on the generic itself so type inference works
-    typecheck = get_origin(type) or type
-    if not isinstance(value, typecheck):
-        raise ConversionError(f"f{path} is not of type {typecheck}")
-    return BencodeNode(cast(T, value), path)
+def convert[T: bytes | int](type: type[T], node: BencodeType, path: str) -> T:
+    if not isinstance(node, type):
+        raise ConversionError(f"{path} is not of type {T}")
+    return node
 
 
-def get_children[T: BencodeType](
-    node: BencodeNode[list[BencodeType]], child_type: type[T]
-):
-    parent, parent_path = node
-    for index, child in enumerate(parent):
-        child_path = f"{parent_path}[{index}]"
-        yield build_node(child, child_type, child_path)
+class BencodeList:
+    def __init__(self, node: BencodeType, path: str) -> None:
+        if not isinstance(node, list):
+            raise ConversionError(f"f{path} is not of type list")
+        self._node = node
+        self._path = path
+
+    def get[T: bytes | int](self, t: type[T]) -> Generator[T]:
+        for index, child_node in enumerate(self._node):
+            yield convert(t, child_node, f"{self._path}[{index}]")
+
+    def get_lists(self) -> Generator["BencodeList"]:
+        for index, child_node in enumerate(self._node):
+            yield BencodeList(child_node, f"{self._path}[{index}]")
+
+    def get_dicts(self) -> Generator["BencodeDict"]:
+        for index, child_node in enumerate(self._node):
+            yield BencodeDict(child_node, f"{self._path}[{index}]")
 
 
-@overload
-def get_child[T: BencodeType](
-    node: BencodeNode[dict[bytes, BencodeType]],
-    child_name: bytes,
-    child_type: type[T],
-) -> BencodeNode[T]: ...
-@overload
-def get_child[T: BencodeType](
-    node: BencodeNode[dict[bytes, BencodeType]],
-    child_name: bytes,
-    child_type: type[T],
-    *,
-    default: T,
-) -> BencodeNode[T]: ...
-@overload
-def get_child[T: BencodeType](
-    node: BencodeNode[dict[bytes, BencodeType]],
-    child_name: bytes,
-    child_type: type[T],
-    *,
-    optional: Literal[True],
-) -> BencodeNode[T] | None: ...
-def get_child[T: BencodeType](
-    node: BencodeNode[dict[bytes, BencodeType]],
-    child_name: bytes,
-    child_type: type[T],
-    *,
-    default: T | None = None,
-    optional: bool = False,
-) -> BencodeNode[T] | None:
-    parent, parent_path = node
-    child = parent.get(child_name, default)
-    child_path = f"{parent_path}.{child_name.decode()}"
-    if child is None:
-        if optional:
+class BencodeDict:
+    def __init__(self, node: BencodeType, path: str) -> None:
+        if not isinstance(node, dict):
+            raise ConversionError(f"f{path} is not of type dict")
+        self._node = node
+        self._path = path
+
+    @overload
+    def get[T: bytes | int](self, t: type[T], child_name: bytes) -> T: ...
+    @overload
+    def get[T: bytes | int](
+        self, t: type[T], child_name: bytes, *, default: T
+    ) -> T: ...
+    @overload
+    def get[T: bytes | int](
+        self, t: type[T], child_name: bytes, *, optional: Literal[True]
+    ) -> None | T: ...
+    def get[T: bytes | int](
+        self,
+        t: type[T],
+        child_name: bytes,
+        *,
+        default: T | None = None,
+        optional: bool = False,
+    ) -> None | T:
+        child = self._get_child(child_name, default, optional)
+        if child is None:
             return None
-        raise ConversionError(f"{child_path} is missing")
-    return build_node(child, child_type, child_path)
+        return convert(t, *child)
 
+    @overload
+    def get_list(self, child_name: bytes) -> BencodeList: ...
+    @overload
+    def get_list(
+        self, child_name: bytes, *, optional: Literal[True]
+    ) -> None | BencodeList: ...
+    def get_list(
+        self, child_name: bytes, *, optional: bool = False
+    ) -> None | BencodeList:
+        child = self._get_child(child_name, None, optional)
+        if child is None:
+            return None
+        return BencodeList(*child)
 
-def bencode(data: BencodeType) -> bytes:
-    return bencodepy.bencode(data)  # type: ignore
+    @overload
+    def get_dict(self, name: bytes) -> "BencodeDict": ...
+    @overload
+    def get_dict(
+        self, name: bytes, *, optional: Literal[True]
+    ) -> "None | BencodeDict": ...
+    def get_dict(self, name: bytes, *, optional: bool = False) -> "None | BencodeDict":
+        child = self._get_child(name, None, optional)
+        if child is None:
+            return None
+        return BencodeDict(*child)
 
+    def _get_child(self, name: bytes, default: BencodeType | None, optional: bool):
+        child_node = self._node.get(name, default)
+        child_path = f"{self._path}.{name.decode()}"
+        if child_node is None:
+            if optional:
+                return None
+            raise ConversionError(f"{child_path} is missing")
+        return child_node, child_path
 
-def bdecode(data: bytes) -> BencodeType:
-    return bencodepy.bdecode(data)  # type: ignore
+    def encode(self) -> bytes:
+        return encode(self._node)
+
+    @staticmethod
+    def decode(encoded: bytes, name: str):
+        decoded = decode(encoded)
+        return BencodeDict(decoded, name)
 
 
 def check_for_qbt_sqlite_resume_db(qbt_bt_backup_dir: str) -> None:
@@ -125,47 +153,38 @@ def check_for_qbt_sqlite_resume_db(qbt_bt_backup_dir: str) -> None:
         raise QbtUsesSqliteForResumeError()
 
 
-def read_bencoded(file_path: str, root_path: str) -> BencodeDict:
-    with open(file_path, "rb") as f:
+def read_bencoded(path: str, name: str) -> BencodeDict:
+    with open(path, "rb") as f:
         try:
-            root = bdecode(f.read())
+            data = f.read()
         except (ValueError, bencodepy.BencodeDecodeError) as e:
-            raise ReadBencodedError(file_path) from e
-    return build_node(root, dict[bytes, BencodeType], root_path)
+            raise ReadBencodedError(path) from e
+    return BencodeDict.decode(data, name)
 
 
 # FIXME BEP0003 says that clients must not perform a decode-encode
 # roundtrip on invalid data. this is exactly what this does.
 def calc_info_hash(torrent: BencodeDict) -> str:
-    info, _ = get_child(torrent, b"info", dict[bytes, BencodeType])
-    return hashlib.sha1(bencode(info)).hexdigest()
+    return hashlib.sha1(torrent.get_dict(b"info").encode()).hexdigest()
 
 
 def transmission_get_speed_limit(resume: BencodeDict, key: bytes) -> int:
-    speed_limit_obj = get_child(resume, key, dict[bytes, BencodeType])
-    use_speed_limit, _ = get_child(speed_limit_obj, b"use-speed-limit", int)
-    if use_speed_limit != 0:
-        return get_child(speed_limit_obj, b"speed-Bps", int).value
+    speed_limit_obj = resume.get_dict(key)
+    if speed_limit_obj.get(int, b"use-speed-limit") != 0:
+        return speed_limit_obj.get(int, b"speed-Bps")
 
     return -1
 
 
 def transmission_get_file_priorities(resume: BencodeDict) -> Generator[int]:
-    priority_node = get_child(resume, b"priority", list[BencodeType], optional=True)
-    dnd_node = get_child(resume, b"dnd", list[BencodeType], optional=True)
+    priority = resume.get_list(b"priority", optional=True)
+    dnd = resume.get_list(b"dnd", optional=True)
 
     # Return empty list if priority data is not available
-    if priority_node is None or dnd_node is None:
+    if priority is None or dnd is None:
         return
 
-    priority = priority_node.value
-    dnd = dnd_node.value
-    if len(priority) != len(dnd):
-        raise ConversionError(
-            f"priority and dnd lengths are not equal : {len(priority)} != {len(dnd)}"
-        )
-
-    for i, (p, d) in enumerate(zip(priority, dnd, strict=True)):
+    for i, (p, d) in enumerate(zip(priority.get(int), dnd.get(int), strict=True)):
         if d == 1:
             yield 0  # libtorrent::dont_download
         else:
@@ -180,52 +199,53 @@ def transmission_get_file_priorities(resume: BencodeDict) -> Generator[int]:
                     raise ConversionError(f"Unknown priority[{i}]: {p}")
 
 
-def peers_convert_from_raw_bytes(src: bytes, addr_size: int) -> bytes:
+def peers_convert_from_raw_bytes(
+    resume: BencodeDict, key: bytes, addr_size: int
+) -> bytes:
+    peers = resume.get(bytes, key, optional=True)
+    if peers is None:
+        return b""
+
     rv = bytearray()
     i = 0
-    while i < len(src):
+    while i < len(peers):
         i += 4  # type
-        rv += src[i : (i + addr_size)]  # addr
+        rv += peers[i : (i + addr_size)]  # addr
         i += max(addr_size, 16)
-        rv += src[i : (i + 2)]  # port
+        rv += peers[i : (i + 2)]  # port
         i += 2
         i += 2  # flags
     return bytes(rv)
 
 
 def peers_convert_from_bencoded(resume: BencodeDict, key: bytes) -> bytes:
-    # used since Transmission commit 1054ba4 (earliest release - 4.1.0)
-
-    peers = get_child(resume, key, list[BencodeType])
-    rv = bytearray()
-    for d in get_children(peers, dict[bytes, BencodeType]):
-        rv += get_child(d, b"socket_address", bytes).value
-    return bytes(rv)
+    peers = resume.get_list(key, optional=True)
+    if peers is None:
+        return b""
+    return b"".join(d.get(bytes, b"socket_address") for d in peers.get_dicts())
 
 
 def transmission_get_peers(resume: BencodeDict, key: bytes, addr_size: int) -> bytes:
-    src = resume.value.get(key)
-    if src is None:
-        return b""
-
-    if isinstance(src, bytes):
-        return peers_convert_from_raw_bytes(src, addr_size)
-    else:
+    try:
+        # Transmission 4.1.0+
         return peers_convert_from_bencoded(resume, key)
+    except:
+        # Older Transmission
+        return peers_convert_from_raw_bytes(resume, key, addr_size)
 
 
 def transmission_get_limit(resume: BencodeDict, limit_kind: str) -> int:
     limit_key = f"{limit_kind}-limit".encode()
-    limit_obj = get_child(resume, limit_key, dict[bytes, BencodeType])
+    limit_obj = resume.get_dict(limit_key)
 
     mode_key = f"{limit_kind}-mode".encode()
-    limit_mode, _ = get_child(limit_obj, mode_key, int)
+    limit_mode = limit_obj.get(int, mode_key)
 
     match limit_mode:
         case 0:  # TR_*LIMIT_GLOBAL
             return -2  # BitTorrent::Torrent::USE_GLOBAL_*
         case 1:  # TR_*LIMIT_SINGLE
-            return get_child(limit_obj, limit_key, int).value
+            return limit_obj.get(int, limit_key)
         case 2:  # TR_*LIMIT_UNLIMITED
             return -1  # BitTorrent::Torrent::NO_*_LIMIT
         case _:
@@ -324,17 +344,11 @@ def is_piece_complete(
 
 
 def transmission_get_pieces(torrent: BencodeDict, resume: BencodeDict) -> bytes:
-    info = get_child(torrent, b"info", dict[bytes, BencodeType])
-    torrent_size_node = get_child(info, b"length", int, optional=True)
-    if torrent_size_node is None:
-        files = get_child(info, b"files", list[BencodeType])
-        torrent_size = sum(
-            get_child(file, b"length", int).value
-            for file in get_children(files, dict[bytes, BencodeType])
-        )
-    else:
-        torrent_size, _ = torrent_size_node
-    piece_size, _ = get_child(info, b"piece length", int)
+    torrent_info = torrent.get_dict(b"info")
+    torrent_size = torrent_info.get(int, b"length", optional=True) or sum(
+        file.get(int, b"length") for file in torrent_info.get_list(b"files").get_dicts()
+    )
+    piece_size = torrent_info.get(int, b"piece length")
 
     # Sanity check the piece size
     if piece_size % BLOCK_SIZE > 0:
@@ -347,8 +361,7 @@ def transmission_get_pieces(torrent: BencodeDict, resume: BencodeDict) -> bytes:
     num_pieces = -(-torrent_size // piece_size)
     num_blocks = -(-torrent_size // BLOCK_SIZE)
 
-    progress = get_child(resume, b"progress", dict[bytes, BencodeType])
-    tr_blocks, _ = get_child(progress, b"blocks", bytes)
+    tr_blocks = resume.get_dict(b"progress").get(bytes, b"blocks")
 
     # Shorthand for complete torrents
     if tr_blocks == b"all":
@@ -379,32 +392,22 @@ def transmission_get_pieces(torrent: BencodeDict, resume: BencodeDict) -> bytes:
 def transmission_get_files(
     torrent_info: BencodeDict, resume: BencodeDict
 ) -> None | list[BencodeType]:
-    resume_files_node = get_child(resume, b"files", list[BencodeType], optional=True)
-    if resume_files_node is None:
+    resume_files = resume.get_list(b"files", optional=True)
+    if resume_files is None:
         return None
+    actual_files: list[BencodeType] = list(resume_files.get(bytes))
 
-    torrent_name, _ = get_child(torrent_info, b"name", bytes)
-
-    actual_files: list[BencodeType] = [
-        f.value for f in get_children(resume_files_node, bytes)
-    ]
-
-    torrent_files_node = get_child(
-        torrent_info, b"files", list[BencodeType], optional=True
-    )
-    if torrent_files_node is None:
+    torrent_name = torrent_info.get(bytes, b"name")
+    torrent_files = torrent_info.get_list(b"files", optional=True)
+    if torrent_files is None:
         # Single-file torrent
         expected_files = [torrent_name]
     else:
         # Multi-file torrent
-        torrent_files = torrent_files_node
-        expected_files = list[bytes]()
-        for torrent_file in get_children(torrent_files, dict[bytes, BencodeType]):
-            paths = get_child(torrent_file, b"path", list[BencodeType])
-            expected_files.append(
-                torrent_name
-                + b"/".join(path.value for path in get_children(paths, bytes))
-            )
+        expected_files = [
+            torrent_name + b"/".join(torrent_file.get_list(b"path").get(bytes))
+            for torrent_file in torrent_files.get_dicts()
+        ]
 
     if actual_files == expected_files:
         # mapped_files is not present if no file is renamed
@@ -416,57 +419,55 @@ def transmission_get_files(
 def map_resume_to_qbt(
     info_hash: str, torrent: BencodeDict, resume: BencodeDict
 ) -> dict[bytes, BencodeType]:
-    downloading_time_seconds, _ = get_child(resume, b"downloading-time-seconds", int)
-    seeding_time_seconds, _ = get_child(resume, b"seeding-time-seconds", int)
-    resume_name, _ = get_child(resume, b"name", bytes)
-    paused, _ = get_child(resume, b"paused", int)
+    downloading_time_seconds = resume.get(int, b"downloading-time-seconds")
+    seeding_time_seconds = resume.get(int, b"seeding-time-seconds")
+    resume_name = resume.get(bytes, b"name")
+    paused = resume.get(int, b"paused")
 
     qbt_resume_data: BencodeType = {
         b"file-format": b"libtorrent resume file",
         b"file-version": 1,
         b"info-hash": binascii.unhexlify(info_hash),
         b"name": resume_name,
-        b"total_uploaded": get_child(resume, b"uploaded", int).value,
-        b"total_downloaded": get_child(resume, b"downloaded", int).value,
-        b"added_time": get_child(resume, b"added-date", int).value,
-        b"completed_time": get_child(resume, b"done-date", int).value,
+        b"total_uploaded": resume.get(int, b"uploaded"),
+        b"total_downloaded": resume.get(int, b"downloaded"),
+        b"added_time": resume.get(int, b"added-date"),
+        b"completed_time": resume.get(int, b"done-date"),
         b"active_time": downloading_time_seconds + seeding_time_seconds,
         b"finished_time": downloading_time_seconds,
         b"seeding_time": seeding_time_seconds,
-        b"max_connections": get_child(resume, b"max-peers", int).value,
+        b"max_connections": resume.get(int, b"max-peers"),
         b"upload_rate_limit": transmission_get_speed_limit(resume, b"speed-limit-up"),
         b"download_rate_limit": transmission_get_speed_limit(
             resume, b"speed-limit-down"
         ),
-        b"save_path": get_child(resume, b"destination", bytes).value,
+        b"save_path": resume.get(bytes, b"destination"),
         b"paused": paused,
-        b"sequential_download": get_child(
-            resume, b"sequentialDownload", int, default=0
-        ).value,
+        b"sequential_download": resume.get(int, b"sequentialDownload", default=0),
         b"file_priority": list(transmission_get_file_priorities(resume)),
         b"qBt-ratioLimit": transmission_get_limit(resume, "ratio"),
         b"qBt-inactiveSeedingTimeLimit": int(transmission_get_limit(resume, "idle")),
-        b"qBt-savePath": get_child(resume, b"destination", bytes).value,
+        b"qBt-savePath": resume.get(bytes, b"destination"),
         b"pieces": transmission_get_pieces(torrent, resume),
     }
 
-    torrent_info = get_child(torrent, b"info", dict[bytes, BencodeType])
+    torrent_info = torrent.get_dict(b"info")
 
-    private, _ = get_child(torrent_info, b"private", int, default=0)
-    if not private:
+    if not torrent_info.get(int, b"private", default=0):
         qbt_resume_data[b"peers"] = transmission_get_peers(resume, b"peers2", 4)
         qbt_resume_data[b"peers6"] = transmission_get_peers(resume, b"peers2-6", 16)
 
-    group = get_child(resume, b"group", bytes, optional=True)
+    group = resume.get(bytes, b"group", optional=True)
     if group is not None:
-        qbt_resume_data[b"qBt-category"], _ = group
+        qbt_resume_data[b"qBt-category"] = group
 
-    labels = get_child(resume, b"labels", list[BencodeType], optional=True)
+    labels = resume.get_list(b"labels", optional=True)
     if labels is not None:
-        qbt_resume_data[b"qBt-tags"], _ = labels
+        qbt_resume_data[b"qBt-tags"] = list(labels.get(bytes))
 
     # qBt-name is present but empty when the torrent is not renamed
-    if resume_name == get_child(torrent_info, b"name", bytes):
+    torrent_name = torrent_info.get(bytes, b"name")
+    if resume_name == torrent_name:
         qbt_resume_data[b"qBt-name"] = b""
     else:
         qbt_resume_data[b"qBt-name"] = resume_name
@@ -475,9 +476,9 @@ def map_resume_to_qbt(
     if files is not None:
         qbt_resume_data[b"mapped_files"] = files
 
-    incomplete_dir = get_child(resume, b"incomplete_dir", bytes, optional=True)
+    incomplete_dir = resume.get(bytes, b"incomplete_dir", optional=True)
     if incomplete_dir is not None:
-        qbt_resume_data[b"qBt-downloadPath"], _ = incomplete_dir
+        qbt_resume_data[b"qBt-downloadPath"] = incomplete_dir
 
     if paused == 1:
         qbt_resume_data[b"auto_managed"] = 0
@@ -515,7 +516,7 @@ class TransmissionQbtImporter:
         resume: BencodeDict,
     ) -> None:
         qbt_resume_data = map_resume_to_qbt(info_hash, torrent, resume)
-        qbt_resume_enc = bencode(qbt_resume_data)
+        qbt_resume_enc = encode(qbt_resume_data)
         qbt_resume_path = os.path.join(self._target_dir, info_hash + ".fastresume")
         qbt_torrent_path = os.path.join(self._target_dir, info_hash + ".torrent")
         if self._dry_run:

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -38,6 +38,8 @@ class QbtUsesSqliteForResumeError(RuntimeError):
 
 type BencodeType = bytes | int | list[BencodeType] | dict[bytes, BencodeType]
 
+type BencodeWrap = bytes | int | BencodeList | BencodeDict
+
 
 def encode(data: BencodeType) -> bytes:
     return bencodepy.encode(data)  # type: ignore
@@ -47,8 +49,12 @@ def decode(data: bytes) -> BencodeType:
     return bencodepy.decode(data)  # type: ignore
 
 
-def convert[T: bytes | int](type: type[T], node: BencodeType, path: str) -> T:
-    if not isinstance(node, type):
+def wrap[T: BencodeWrap](t: type[T], node: BencodeType, path: str) -> T:
+    if t is BencodeList:
+        return cast(T, BencodeList(node, path))
+    if t is BencodeDict:
+        return cast(T, BencodeDict(node, path))
+    if not isinstance(node, t):
         raise ConversionError(f"{path} is not of type {T}")
     return node
 
@@ -60,17 +66,9 @@ class BencodeList:
         self._node = node
         self._path = path
 
-    def get[T: bytes | int](self, t: type[T]) -> Generator[T]:
+    def cast[T: BencodeWrap](self, t: type[T]) -> Generator[T]:
         for index, child_node in enumerate(self._node):
-            yield convert(t, child_node, f"{self._path}[{index}]")
-
-    def get_lists(self) -> Generator["BencodeList"]:
-        for index, child_node in enumerate(self._node):
-            yield BencodeList(child_node, f"{self._path}[{index}]")
-
-    def get_dicts(self) -> Generator["BencodeDict"]:
-        for index, child_node in enumerate(self._node):
-            yield BencodeDict(child_node, f"{self._path}[{index}]")
+            yield wrap(t, child_node, f"{self._path}[{index}]")
 
 
 class BencodeDict:
@@ -81,54 +79,30 @@ class BencodeDict:
         self._path = path
 
     @overload
-    def get[T: bytes | int](self, t: type[T], key: bytes) -> T: ...
+    def get[T: BencodeWrap](self, t: type[T], key: bytes) -> T: ...
     @overload
-    def get[T: bytes | int](self, t: type[T], key: bytes, *, default: T) -> T: ...
+    def get[T: BencodeWrap](
+        self, t: type[T], key: bytes, *, default: BencodeType
+    ) -> T: ...
     @overload
-    def get[T: bytes | int](
+    def get[T: BencodeWrap](
         self, t: type[T], key: bytes, *, opt: Literal[True]
     ) -> None | T: ...
-    def get[T: bytes | int](
+    def get[T: BencodeWrap](
         self,
         t: type[T],
         key: bytes,
         *,
-        default: T | None = None,
+        default: BencodeType | None = None,
         opt: bool = False,
     ) -> None | T:
-        child = self._get_child(key, default, opt)
-        if child is None:
-            return None
-        return convert(t, *child)
-
-    @overload
-    def get_list(self, key: bytes) -> BencodeList: ...
-    @overload
-    def get_list(self, key: bytes, *, opt: Literal[True]) -> None | BencodeList: ...
-    def get_list(self, key: bytes, *, opt: bool = False) -> None | BencodeList:
-        child = self._get_child(key, None, opt)
-        if child is None:
-            return None
-        return BencodeList(*child)
-
-    @overload
-    def get_dict(self, key: bytes) -> "BencodeDict": ...
-    @overload
-    def get_dict(self, key: bytes, *, opt: Literal[True]) -> "None | BencodeDict": ...
-    def get_dict(self, key: bytes, *, opt: bool = False) -> "None | BencodeDict":
-        child = self._get_child(key, None, opt)
-        if child is None:
-            return None
-        return BencodeDict(*child)
-
-    def _get_child(self, key: bytes, default: BencodeType | None, opt: bool):
         child_node = self._node.get(key, default)
         child_path = f"{self._path}.{key.decode()}"
         if child_node is None:
             if opt:
                 return None
             raise ConversionError(f"{child_path} is missing")
-        return child_node, child_path
+        return wrap(t, child_node, child_path)
 
     def encode(self) -> bytes:
         return encode(self._node)
@@ -157,11 +131,11 @@ def read_bencoded(path: str, name: str) -> BencodeDict:
 # FIXME BEP0003 says that clients must not perform a decode-encode
 # roundtrip on invalid data. this is exactly what this does.
 def calc_info_hash(torrent: BencodeDict) -> str:
-    return hashlib.sha1(torrent.get_dict(b"info").encode()).hexdigest()
+    return hashlib.sha1(torrent.get(BencodeDict, b"info").encode()).hexdigest()
 
 
 def transmission_get_speed_limit(resume: BencodeDict, key: bytes) -> int:
-    speed_limit_obj = resume.get_dict(key)
+    speed_limit_obj = resume.get(BencodeDict, key)
     if speed_limit_obj.get(int, b"use-speed-limit") != 0:
         return speed_limit_obj.get(int, b"speed-Bps")
 
@@ -169,14 +143,14 @@ def transmission_get_speed_limit(resume: BencodeDict, key: bytes) -> int:
 
 
 def transmission_get_file_priorities(resume: BencodeDict) -> Generator[int]:
-    priority = resume.get_list(b"priority", opt=True)
-    dnd = resume.get_list(b"dnd", opt=True)
+    priority = resume.get(BencodeList, b"priority", opt=True)
+    dnd = resume.get(BencodeList, b"dnd", opt=True)
 
     # Return empty list if priority data is not available
     if priority is None or dnd is None:
         return
 
-    for i, (p, d) in enumerate(zip(priority.get(int), dnd.get(int), strict=True)):
+    for i, (p, d) in enumerate(zip(priority.cast(int), dnd.cast(int), strict=True)):
         if d == 1:
             yield 0  # libtorrent::dont_download
         else:
@@ -211,10 +185,10 @@ def peers_convert_from_raw_bytes(
 
 
 def peers_convert_from_bencoded(resume: BencodeDict, key: bytes) -> bytes:
-    peers = resume.get_list(key, opt=True)
+    peers = resume.get(BencodeList, key, opt=True)
     if peers is None:
         return b""
-    return b"".join(d.get(bytes, b"socket_address") for d in peers.get_dicts())
+    return b"".join(d.get(bytes, b"socket_address") for d in peers.cast(BencodeDict))
 
 
 def transmission_get_peers(resume: BencodeDict, key: bytes, addr_size: int) -> bytes:
@@ -228,7 +202,7 @@ def transmission_get_peers(resume: BencodeDict, key: bytes, addr_size: int) -> b
 
 def transmission_get_limit(resume: BencodeDict, limit_kind: str) -> int:
     limit_key = f"{limit_kind}-limit".encode()
-    limit_obj = resume.get_dict(limit_key)
+    limit_obj = resume.get(BencodeDict, limit_key)
 
     mode_key = f"{limit_kind}-mode".encode()
     limit_mode = limit_obj.get(int, mode_key)
@@ -336,9 +310,10 @@ def is_piece_complete(
 
 
 def transmission_get_pieces(torrent: BencodeDict, resume: BencodeDict) -> bytes:
-    torrent_info = torrent.get_dict(b"info")
+    torrent_info = torrent.get(BencodeDict, b"info")
     torrent_size = torrent_info.get(int, b"length", opt=True) or sum(
-        file.get(int, b"length") for file in torrent_info.get_list(b"files").get_dicts()
+        file.get(int, b"length")
+        for file in torrent_info.get(BencodeList, b"files").cast(BencodeDict)
     )
     piece_size = torrent_info.get(int, b"piece length")
 
@@ -353,7 +328,7 @@ def transmission_get_pieces(torrent: BencodeDict, resume: BencodeDict) -> bytes:
     num_pieces = -(-torrent_size // piece_size)
     num_blocks = -(-torrent_size // BLOCK_SIZE)
 
-    tr_blocks = resume.get_dict(b"progress").get(bytes, b"blocks")
+    tr_blocks = resume.get(BencodeDict, b"progress").get(bytes, b"blocks")
 
     # Shorthand for complete torrents
     if tr_blocks == b"all":
@@ -384,21 +359,21 @@ def transmission_get_pieces(torrent: BencodeDict, resume: BencodeDict) -> bytes:
 def transmission_get_files(
     torrent_info: BencodeDict, resume: BencodeDict
 ) -> None | list[BencodeType]:
-    resume_files = resume.get_list(b"files", opt=True)
+    resume_files = resume.get(BencodeList, b"files", opt=True)
     if resume_files is None:
         return None
-    actual_files: list[BencodeType] = list(resume_files.get(bytes))
+    actual_files: list[BencodeType] = list(resume_files.cast(bytes))
 
     torrent_name = torrent_info.get(bytes, b"name")
-    torrent_files = torrent_info.get_list(b"files", opt=True)
+    torrent_files = torrent_info.get(BencodeList, b"files", opt=True)
     if torrent_files is None:
         # Single-file torrent
         expected_files = [torrent_name]
     else:
         # Multi-file torrent
         expected_files = [
-            torrent_name + b"/".join(torrent_file.get_list(b"path").get(bytes))
-            for torrent_file in torrent_files.get_dicts()
+            torrent_name + b"/".join(torrent_file.get(BencodeList, b"path").cast(bytes))
+            for torrent_file in torrent_files.cast(BencodeDict)
         ]
 
     if actual_files == expected_files:
@@ -443,7 +418,7 @@ def map_resume_to_qbt(
         b"pieces": transmission_get_pieces(torrent, resume),
     }
 
-    torrent_info = torrent.get_dict(b"info")
+    torrent_info = torrent.get(BencodeDict, b"info")
 
     if not torrent_info.get(int, b"private", default=0):
         qbt_resume_data[b"peers"] = transmission_get_peers(resume, b"peers2", 4)
@@ -453,9 +428,9 @@ def map_resume_to_qbt(
     if group is not None:
         qbt_resume_data[b"qBt-category"] = group
 
-    labels = resume.get_list(b"labels", opt=True)
+    labels = resume.get(BencodeList, b"labels", opt=True)
     if labels is not None:
-        qbt_resume_data[b"qBt-tags"] = list(labels.get(bytes))
+        qbt_resume_data[b"qBt-tags"] = list(labels.cast(bytes))
 
     # qBt-name is present but empty when the torrent is not renamed
     torrent_name = torrent_info.get(bytes, b"name")

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -555,10 +555,10 @@ class TransmissionQbtImporter:
         qbt_resume_path = os.path.join(self._target_dir, info_hash + ".fastresume")
         qbt_torrent_path = os.path.join(self._target_dir, info_hash + ".torrent")
         if self._dry_run:
-            logging.info(
+            logging.debug(
                 f"dry run: would save {naturalsize(len(qbt_resume_enc), binary=True)} to {qbt_resume_path}"
             )
-            logging.info(
+            logging.debug(
                 f"dry run: would copy {source_tor_abs_path} to {qbt_torrent_path}"
             )
         else:
@@ -566,23 +566,24 @@ class TransmissionQbtImporter:
                 with open(qbt_resume_path, "wb") as resumf:
                     resumf.write(qbt_resume_enc)
                 shutil.copy(source_tor_abs_path, qbt_torrent_path)
-                logging.info(
+                logging.debug(
                     f"Successfully imported {os.path.basename(source_tor_abs_path)} ({info_hash})"
                 )
 
-            except:
-                logging.warning(
-                    f"Could not copy files for {os.path.basename(source_tor_abs_path)} ({info_hash}) into {self._target_dir}"
-                )
+            except Exception as e:
                 rm_f(qbt_resume_path)
                 rm_f(qbt_torrent_path)
+                raise ConversionError(
+                    f"Could not copy files for {os.path.basename(source_tor_abs_path)} ({info_hash}) into {self._target_dir}",
+                    e,
+                )
 
     def copy_if_wanted(
         self,
         source_tor_abs_path: str,
         source_res_abs_path: str,
         info_hash: str | None,
-    ) -> None:
+    ) -> bool:
         torrent = read_bencoded(source_tor_abs_path, "torrent")
 
         resume = read_bencoded(source_res_abs_path, "resume")
@@ -596,58 +597,66 @@ class TransmissionQbtImporter:
             try:
                 predicate_rv = eval(self._filter)
             except Exception as e:
-                logging.info(
-                    f"Predicate threw {type(e).__name__} with {e} for torrent {info_hash}, skipping"
+                logging.warning(
+                    f"Predicate threw {type(e).__name__} for torrent {info_hash}, skipping",
+                    exc_info=e,
                 )
-                return
+                return False
 
         if predicate_rv:
             self.copy_to_target(source_tor_abs_path, info_hash, torrent, resume)
+            return True
         else:
             logging.debug(
                 f"Predicate returned {predicate_rv} for torrent {info_hash}, skipping"
             )
+            return False
 
-    def import_one(self, torf: str) -> None:
+    def import_one(self, torf: str) -> bool:
         match = self._torrent_file_300_rgx.fullmatch(torf)
         if match:
             info_hash = match[1]
-            self.copy_if_wanted(
+            return self.copy_if_wanted(
                 os.path.join(self.source_torrents_dir, torf),
                 os.path.join(self._source_resume_dir, info_hash + ".resume"),
                 match[1],
             )
-            return
 
         match = self._torrent_file_294_rgx.search(torf)
         if match:
-            self.copy_if_wanted(
+            return self.copy_if_wanted(
                 os.path.join(self.source_torrents_dir, torf),
                 os.path.join(
                     self._source_resume_dir, os.path.splitext(torf)[0] + ".resume"
                 ),
                 None,
             )
-            return
 
         logging.warning(f"Unknown file {torf} found in torrents directory, skipping")
+        return False
 
     def scan(self) -> None:
+        success, failure, ignored = 0, 0, 0
         for _, _, files in os.walk(self.source_torrents_dir):
             for torf in files:
                 try:
-                    self.import_one(torf)
-
+                    if self.import_one(torf):
+                        success += 1
+                    else:
+                        ignored += 1
+                    continue
                 except ConversionError as e:
-                    logging.warning(
-                        f"Error while converting resume data for {torf} : {e}"
+                    logging.error(
+                        f"Error while converting resume data for {torf}", exc_info=e
                     )
                 except OSError as e:
-                    logging.warning(
-                        f"Failed to read {e.filename} ({e.strerror}), skipping"
-                    )
+                    logging.error(f"Failed to read file, skipping", exc_info=e)
                 except ReadBencodedError as e:
-                    logging.warning(f"Failed to decode {e}, skipping")
+                    logging.error(f"Failed to decode, skipping", exc_info=e)
+                failure += 1
+        logging.info(
+            f"Operation complete with {success} torrent(s) migrated {"(dry run)" if self._dry_run else ''}, {failure} torrent(s) failed and {ignored} torrent(s) ignored"
+        )
 
 
 def main() -> int:
@@ -673,7 +682,7 @@ def main() -> int:
         "--add-paused",
         "-p",
         action="store_true",
-        help="Optional flag to add all torrents paused rather than using the resume status",
+        help="Optional flag to add all torrents paused rather than using the Transmission status",
     )
     parser.add_argument(
         "--dry-run",
@@ -695,7 +704,7 @@ def main() -> int:
     try:
         TransmissionQbtImporter(args).scan()
     except QbtUsesSqliteForResumeError:
-        logging.error(
+        logging.critical(
             """It looks like your qBittorrent instance uses the experimental SQLite-based
 implementation for resume data storage. This is not supported. If you want to
 use this script, go to Tools > Preferences > Advanced and change "Resume data

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -14,6 +14,7 @@ import hashlib
 
 
 import bencodepy
+from humanize import naturalsize
 
 
 class ConversionError(RuntimeError):
@@ -38,7 +39,6 @@ class QbtUsesSqliteForResumeError(RuntimeError):
 type BencodeType = bytes | int | list[BencodeType] | dict[bytes, BencodeType]
 
 
-@dataclass(frozen=True)
 class BencodeNode[T: BencodeType](NamedTuple):
     # A class for convenience, which carries the full path of the node
     # e.g. value=xxx, path="torrent.info.length"
@@ -267,8 +267,11 @@ def transmission_get_pieces(torrent: BencodeDict, resume: BencodeDict) -> bytes:
     # (where n=piece_size//BLOCK_SIZE//8), and checking that they are all 0xff
     # For this to work without having to do bitwise operations, the piece size must be at least 8x the block size
     # The block size is 16KiB so the minimum piece size is 128KiB
-    if piece_size < 1 << 17:  # 128KiB
-        raise ConversionError(f"Piece size {piece_size} is lower than 128KiB, aborting")
+    min_piece_size = 8 * BLOCK_SIZE
+    if piece_size < min_piece_size:
+        raise ConversionError(
+            f"Piece size {naturalsize(min_piece_size, binary=True)} is lower than {naturalsize(min_piece_size, binary=True)}, aborting"
+        )
 
     progress = get_child(resume, b"progress", dict[bytes, BencodeType])
     blocks, _ = get_child(progress, b"blocks", bytes)
@@ -315,7 +318,7 @@ def map_resume_to_qbt(
     info_hash: str, torrent: BencodeDict, resume: BencodeDict
 ) -> dict[bytes, BencodeType]:
     downloading_time_seconds, _ = get_child(resume, b"downloading-time-seconds", int)
-    seeding_time_seconds, _ = get_child(resume, b"seeding-time-second", int)
+    seeding_time_seconds, _ = get_child(resume, b"seeding-time-seconds", int)
     name, _ = get_child(resume, b"name", bytes)
     paused, _ = get_child(resume, b"paused", int)
 
@@ -378,6 +381,7 @@ class Args:
     qbt_bt_backup_dir: str
     transmission_config_dir: str
     predicate: str | None
+    dry_run: bool
 
 
 class TransmissionQbtImporter:
@@ -386,11 +390,12 @@ class TransmissionQbtImporter:
         self.source_torrents_dir = os.path.join(
             args.transmission_config_dir, "torrents"
         )
-        self.source_resume_dir = os.path.join(args.transmission_config_dir, "resume")
-        self.target_dir = args.qbt_bt_backup_dir
-        self.predicate = args.predicate
-        self.torrent_file_300_rgx = re.compile("([0-9a-f]{40})\\.torrent")
-        self.torrent_file_294_rgx = re.compile("\\.[0-9a-f]{16}\\.torrent$")
+        self._source_resume_dir = os.path.join(args.transmission_config_dir, "resume")
+        self._target_dir = args.qbt_bt_backup_dir
+        self._predicate = args.predicate
+        self._dry_run = args.dry_run
+        self._torrent_file_300_rgx = re.compile("([0-9a-f]{40})\\.torrent")
+        self._torrent_file_294_rgx = re.compile("\\.[0-9a-f]{16}\\.torrent$")
 
     def copy_to_target(
         self,
@@ -398,24 +403,34 @@ class TransmissionQbtImporter:
         info_hash: str,
         torrent: BencodeDict,
         resume: BencodeDict,
+        dry_run: bool,
     ) -> None:
         qbt_resume_data = map_resume_to_qbt(info_hash, torrent, resume)
-        qbt_resume_path = os.path.join(self.target_dir, info_hash + ".fastresume")
-        qbt_torrent_path = os.path.join(self.target_dir, info_hash + ".torrent")
-        try:
-            with open(qbt_resume_path, "wb") as resumf:
-                resumf.write(bencode(qbt_resume_data))
-            shutil.copy(source_tor_abs_path, qbt_torrent_path)
+        qbt_resume_enc = bencode(qbt_resume_data)
+        qbt_resume_path = os.path.join(self._target_dir, info_hash + ".fastresume")
+        qbt_torrent_path = os.path.join(self._target_dir, info_hash + ".torrent")
+        if dry_run:
             logging.info(
-                f"Successfully imported {os.path.basename(source_tor_abs_path)} ({info_hash})"
+                f"dry run: would save {naturalsize(len(qbt_resume_enc), binary=True)} to {qbt_resume_path}"
             )
+            logging.info(
+                f"dry run: would copy {source_tor_abs_path} to {qbt_torrent_path}"
+            )
+        else:
+            try:
+                with open(qbt_resume_path, "wb") as resumf:
+                    resumf.write(qbt_resume_enc)
+                shutil.copy(source_tor_abs_path, qbt_torrent_path)
+                logging.info(
+                    f"Successfully imported {os.path.basename(source_tor_abs_path)} ({info_hash})"
+                )
 
-        except:
-            logging.warning(
-                f"Could not copy files for {os.path.basename(source_tor_abs_path)} ({info_hash}) into {self.target_dir}"
-            )
-            rm_f(qbt_resume_path)
-            rm_f(qbt_torrent_path)
+            except:
+                logging.warning(
+                    f"Could not copy files for {os.path.basename(source_tor_abs_path)} ({info_hash}) into {self._target_dir}"
+                )
+                rm_f(qbt_resume_path)
+                rm_f(qbt_torrent_path)
 
     def copy_if_wanted(
         self,
@@ -430,11 +445,11 @@ class TransmissionQbtImporter:
         if info_hash is None:
             info_hash = calc_info_hash(torrent)
 
-        if self.predicate is None:
+        if self._predicate is None:
             predicate_rv = True
         else:
             try:
-                predicate_rv = eval(self.predicate)
+                predicate_rv = eval(self._predicate)
             except Exception as e:
                 logging.info(
                     f"Predicate threw {type(e).__name__} with {e} for torrent {info_hash}, skipping"
@@ -442,29 +457,31 @@ class TransmissionQbtImporter:
                 return
 
         if predicate_rv is True:
-            self.copy_to_target(source_tor_abs_path, info_hash, torrent, resume)
+            self.copy_to_target(
+                source_tor_abs_path, info_hash, torrent, resume, self._dry_run
+            )
         else:
             logging.info(
                 f"Predicate returned {predicate_rv} for torrent {info_hash}, skipping"
             )
 
     def import_one(self, torf: str) -> None:
-        match = self.torrent_file_300_rgx.fullmatch(torf)
+        match = self._torrent_file_300_rgx.fullmatch(torf)
         if match:
             info_hash = match[1]
             self.copy_if_wanted(
                 os.path.join(self.source_torrents_dir, torf),
-                os.path.join(self.source_resume_dir, info_hash + ".resume"),
+                os.path.join(self._source_resume_dir, info_hash + ".resume"),
                 match[1],
             )
             return
 
-        match = self.torrent_file_294_rgx.search(torf)
+        match = self._torrent_file_294_rgx.search(torf)
         if match:
             self.copy_if_wanted(
                 os.path.join(self.source_torrents_dir, torf),
                 os.path.join(
-                    self.source_resume_dir, os.path.splitext(torf)[0] + ".resume"
+                    self._source_resume_dir, os.path.splitext(torf)[0] + ".resume"
                 ),
                 None,
             )
@@ -499,18 +516,22 @@ def main() -> int:
     )
     parser.add_argument(
         "transmission_config_dir",
-        action="store",
         help="The root configuration directory of the Transmission instance whose torrents to import",
     )
     parser.add_argument(
         "qbt_bt_backup_dir",
-        action="store",
         help="The BT_backup directory inside target qBittorrent instance's data directory",
     )
     parser.add_argument(
         "--predicate",
-        action="store",
+        "-p",
         help="A Python expression for filtering source torrents",
+    )
+    parser.add_argument(
+        "--dry-run",
+        "-d",
+        action="store_true",
+        help="Optional flag to not write any data to disk",
     )
 
     args = cast(Args, parser.parse_args())

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -37,22 +37,26 @@ class QbtUsesSqliteForResumeError(RuntimeError):
 
 
 type BencodeType = bytes | int | list[BencodeType] | dict[bytes, BencodeType]
+"""A helper alias for the types that bencode data nodes can represent."""
 
 type BencodeWrap = bytes | int | BencodeList | BencodeDict
+"""A helper alias for the wrapper types associated with bencode types."""
 
 
 def encode(data: BencodeType) -> bytes:
+    """Wraps the bencode.py encode function to avoid typechecking errors."""
     return bencodepy.encode(data)  # type: ignore
 
 
 def decode(data: bytes) -> BencodeType:
+    """Wraps the bencode.py decode function to avoid typechecking errors."""
     return bencodepy.decode(data)  # type: ignore
 
 
 def wrap[T: BencodeWrap](t: type[T], node: BencodeType, path: str) -> T:
     """Wraps a bencode type.
-     dicts and lists are wrapped in BencodeList and BencodeDict respectively.
-     Scalar types (bytes & int) are typechecked and returned as is."""
+    dicts and lists are typechecked and wrapped in BencodeList and BencodeDict respectively.
+    Scalar types (bytes & int) are typechecked and returned as is."""
 
     if t is BencodeList:
         if not isinstance(node, list):
@@ -100,30 +104,31 @@ class BencodeDict:
     def get[T: BencodeWrap](self, t: type[T], key: bytes) -> T:
         """Retrieve an item by key. If the key is not present, raises ConversionError."""
         ...
+
     @overload
-    def get[T: BencodeWrap](
-        self, t: type[T], key: bytes, *, default: BencodeType
-    ) -> T:
+    def get[T: BencodeWrap](self, t: type[T], key: bytes, *, default: BencodeType) -> T:
         """Retrieve an item by key. If the key is not present, returns the provided default."""
         ...
+
     @overload
     def get[T: BencodeWrap](
-        self, t: type[T], key: bytes, *, opt: Literal[True]
+        self, t: type[T], key: bytes, *, optional: Literal[True]
     ) -> None | T:
         """Retrieve an item by key. If the key is not present, returns None."""
         ...
+
     def get[T: BencodeWrap](
         self,
         t: type[T],
         key: bytes,
         *,
         default: BencodeType | None = None,
-        opt: bool = False,
+        optional: bool = False,
     ) -> None | T:
         child_node = self._node.get(key, default)
         child_path = f"{self._path}.{key.decode()}"
         if child_node is None:
-            if opt:
+            if optional:
                 return None
             raise ConversionError(f"{child_path} is missing")
         return wrap(t, child_node, child_path)
@@ -169,8 +174,8 @@ def transmission_get_speed_limit(resume: BencodeDict, key: bytes) -> int:
 
 
 def transmission_get_file_priorities(resume: BencodeDict) -> Generator[int]:
-    priority = resume.get(BencodeList, b"priority", opt=True)
-    dnd = resume.get(BencodeList, b"dnd", opt=True)
+    priority = resume.get(BencodeList, b"priority", optional=True)
+    dnd = resume.get(BencodeList, b"dnd", optional=True)
 
     # Return empty list if priority data is not available
     if priority is None or dnd is None:
@@ -194,7 +199,7 @@ def transmission_get_file_priorities(resume: BencodeDict) -> Generator[int]:
 def peers_convert_from_raw_bytes(
     resume: BencodeDict, key: bytes, addr_size: int
 ) -> bytes:
-    peers = resume.get(bytes, key, opt=True)
+    peers = resume.get(bytes, key, optional=True)
     if peers is None:
         return b""
 
@@ -211,7 +216,7 @@ def peers_convert_from_raw_bytes(
 
 
 def peers_convert_from_bencoded(resume: BencodeDict, key: bytes) -> bytes:
-    peers = resume.get(BencodeList, key, opt=True)
+    peers = resume.get(BencodeList, key, optional=True)
     if peers is None:
         return b""
     return b"".join(d.get(bytes, b"socket_address") for d in peers.cast(BencodeDict))
@@ -337,7 +342,7 @@ def is_piece_complete(
 
 def transmission_get_pieces(torrent: BencodeDict, resume: BencodeDict) -> bytes:
     torrent_info = torrent.get(BencodeDict, b"info")
-    torrent_size = torrent_info.get(int, b"length", opt=True) or sum(
+    torrent_size = torrent_info.get(int, b"length", optional=True) or sum(
         file.get(int, b"length")
         for file in torrent_info.get(BencodeList, b"files").cast(BencodeDict)
     )
@@ -385,13 +390,13 @@ def transmission_get_pieces(torrent: BencodeDict, resume: BencodeDict) -> bytes:
 def transmission_get_files(
     torrent_info: BencodeDict, resume: BencodeDict
 ) -> None | list[BencodeType]:
-    resume_files = resume.get(BencodeList, b"files", opt=True)
+    resume_files = resume.get(BencodeList, b"files", optional=True)
     if resume_files is None:
         return None
     actual_files: list[BencodeType] = list(resume_files.cast(bytes))
 
     torrent_name = torrent_info.get(bytes, b"name")
-    torrent_files = torrent_info.get(BencodeList, b"files", opt=True)
+    torrent_files = torrent_info.get(BencodeList, b"files", optional=True)
     if torrent_files is None:
         # Single-file torrent
         expected_files = [torrent_name]
@@ -450,11 +455,11 @@ def map_resume_to_qbt(
         qbt_resume_data[b"peers"] = transmission_get_peers(resume, b"peers2", 4)
         qbt_resume_data[b"peers6"] = transmission_get_peers(resume, b"peers2-6", 16)
 
-    group = resume.get(bytes, b"group", opt=True)
+    group = resume.get(bytes, b"group", optional=True)
     if group is not None:
         qbt_resume_data[b"qBt-category"] = group
 
-    labels = resume.get(BencodeList, b"labels", opt=True)
+    labels = resume.get(BencodeList, b"labels", optional=True)
     if labels is not None:
         qbt_resume_data[b"qBt-tags"] = list(labels.cast(bytes))
 
@@ -469,7 +474,7 @@ def map_resume_to_qbt(
     if files is not None:
         qbt_resume_data[b"mapped_files"] = files
 
-    incomplete_dir = resume.get(bytes, b"incomplete_dir", opt=True)
+    incomplete_dir = resume.get(bytes, b"incomplete_dir", optional=True)
     if incomplete_dir is not None:
         qbt_resume_data[b"qBt-downloadPath"] = incomplete_dir
 

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -36,7 +36,7 @@ class QbtUsesSqliteForResumeError(RuntimeError):
 
 type BencodeList = list["BencodeType"]
 type BencodeDict = dict[bytes, "BencodeType"]
-type BencodeType = bytes | int | BencodeList | dict[bytes, BencodeType]
+type BencodeType = bytes | int | BencodeList | BencodeDict
 
 
 @dataclass(frozen=True)

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -266,7 +266,8 @@ def get_last_piece_mask_for_block_checking(torrent_size: int, piece_size: int):
     last_piece_size = torrent_size % piece_size or piece_size
 
     # Number of blocks in the last piece
-    blocks_in_last_piece = -(-last_piece_size // BLOCK_SIZE)  # Ceiling integer division
+    # Ceiling integer division
+    blocks_in_last_piece = -(-last_piece_size // BLOCK_SIZE)
 
     # Get the start of the mask, made of 1s in groups of 8
     mask_full_bytes = blocks_in_last_piece // 8
@@ -302,15 +303,15 @@ def transmission_get_pieces(parsed_tor: BencodeData, tr_resume: BencodeData):
     blocks = tr_resume.get_dict(b"progress").get_bytes(b"blocks")
 
     # Sanity check the block bytes length
-    expected_num_blocks = -(
-        -torrent_size // BLOCK_SIZE // 8
-    )  # ceiling integer division
+    # ceiling integer division
+    expected_num_blocks = -(-torrent_size // BLOCK_SIZE // 8)
     if len(blocks) != expected_num_blocks:
         raise ConversionError(
             f"resume block length was expected to be {expected_num_blocks} but was {len(blocks)}"
         )
 
-    num_pieces = -(-torrent_size // piece_size)  # ceiling integer division
+    # ceiling integer division
+    num_pieces = -(-torrent_size // piece_size)
 
     # Initialise the return object with 0s
     qbit_pieces = bytearray(num_pieces)

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -342,7 +342,7 @@ def transmission_get_pieces(torrent: BencodeDict, resume: BencodeDict) -> bytes:
     expected_block_bytes = -(-num_blocks // 8)
     if len(tr_blocks) > expected_block_bytes:
         raise ConversionError(
-            f"the resume block length was expected to be {expected_block_bytes} but was {len(tr_blocks)}"
+            f"The resume block length was expected to be {expected_block_bytes} but was {len(tr_blocks)}"
         )
 
     # Initialise the return object with 0s

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -387,46 +387,19 @@ def transmission_get_pieces(torrent: BencodeDict, resume: BencodeDict) -> bytes:
     return bytes(qb_pieces)
 
 
-def transmission_get_files(
-    torrent_info: BencodeDict, resume: BencodeDict
-) -> None | list[BencodeType]:
-    resume_files = resume.get(BencodeList, b"files", optional=True)
-    if resume_files is None:
-        return None
-    actual_files: list[BencodeType] = list(resume_files.cast(bytes))
-
-    torrent_name = torrent_info.get(bytes, b"name")
-    torrent_files = torrent_info.get(BencodeList, b"files", optional=True)
-    if torrent_files is None:
-        # Single-file torrent
-        expected_files = [torrent_name]
-    else:
-        # Multi-file torrent
-        expected_files = [
-            torrent_name + b"/".join(torrent_file.get(BencodeList, b"path").cast(bytes))
-            for torrent_file in torrent_files.cast(BencodeDict)
-        ]
-
-    if actual_files == expected_files:
-        # mapped_files is not present if no file is renamed
-        return None
-
-    return actual_files
-
-
 def map_resume_to_qbt(
     info_hash: str, torrent: BencodeDict, resume: BencodeDict
 ) -> dict[bytes, BencodeType]:
     downloading_time_seconds = resume.get(int, b"downloading-time-seconds")
     seeding_time_seconds = resume.get(int, b"seeding-time-seconds")
-    resume_name = resume.get(bytes, b"name")
+    name = resume.get(bytes, b"name")
     paused = resume.get(int, b"paused")
 
     qbt_resume_data: BencodeType = {
         b"file-format": b"libtorrent resume file",
         b"file-version": 1,
         b"info-hash": binascii.unhexlify(info_hash),
-        b"name": resume_name,
+        b"name": name,
         b"total_uploaded": resume.get(int, b"uploaded"),
         b"total_downloaded": resume.get(int, b"downloaded"),
         b"added_time": resume.get(int, b"added-date"),
@@ -443,6 +416,7 @@ def map_resume_to_qbt(
         b"paused": paused,
         b"sequential_download": resume.get(int, b"sequentialDownload", default=0),
         b"file_priority": list(transmission_get_file_priorities(resume)),
+        b"qBt-name": name,
         b"qBt-ratioLimit": transmission_get_limit(resume, "ratio"),
         b"qBt-inactiveSeedingTimeLimit": int(transmission_get_limit(resume, "idle")),
         b"qBt-savePath": resume.get(bytes, b"destination"),
@@ -463,16 +437,9 @@ def map_resume_to_qbt(
     if labels is not None:
         qbt_resume_data[b"qBt-tags"] = list(labels.cast(bytes))
 
-    # qBt-name is present but empty when the torrent is not renamed
-    torrent_name = torrent_info.get(bytes, b"name")
-    if resume_name == torrent_name:
-        qbt_resume_data[b"qBt-name"] = b""
-    else:
-        qbt_resume_data[b"qBt-name"] = resume_name
-
-    files = transmission_get_files(torrent_info, resume)
+    files = resume.get(BencodeList, b"files", optional=True)
     if files is not None:
-        qbt_resume_data[b"mapped_files"] = files
+        qbt_resume_data[b"mapped_files"] = list(files.cast(bytes))
 
     incomplete_dir = resume.get(bytes, b"incomplete_dir", optional=True)
     if incomplete_dir is not None:

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -50,12 +50,9 @@ class BencodeListWrapper[T: bytes | int](Iterator[T]):
 
     def unwrap(self) -> BencodeList:
         return self._data
-    
+
     def __getitem__(self, key: int) -> T:
-        item = self._data[key]
-        if not isinstance(item, self._item_type):
-            raise ConversionError(f"{self._path}[{key}] is not {T}")
-        return item
+        return self._safecast(self._data[key], key)
 
     def __len__(self) -> int:
         return len(self._data)
@@ -71,6 +68,9 @@ class BencodeListWrapper[T: bytes | int](Iterator[T]):
         except StopIteration:
             raise StopIteration
 
+        return self._safecast(item, self._index)
+
+    def _safecast(self, item: BencodeType, index: int) -> T:
         if not isinstance(item, self._item_type):
             raise ConversionError(f"{self._path}[{self._index}] is not {T}")
         return item

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -180,10 +180,9 @@ def peers_convert_from_raw_bytes(src: bytes, addr_size: int) -> bytes:
 def peers_convert_from_bencoded(src: list[BencodeType], key: bytes) -> bytes:
     # used since Transmission commit 1054ba4 (earliest release - 4.1.0)
     rv = bytearray()
-    for i, d in enumerate(src):
-        d_path = f"{key}[{i}]"
-        d_dict = build_node(dict[bytes, BencodeType], d, d_path)
-        socket_address = get_child(d_dict, b"socket_address", bytes).value
+    for i, x in enumerate(src):
+        d = build_node(dict[bytes, BencodeType], x, f"{key}[{i}]")
+        socket_address, _ = get_child(d, b"socket_address", bytes)
         rv += socket_address
     return bytes(rv)
 

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -287,8 +287,8 @@ def transmission_get_limit(resume: BencodeDict, limit_kind: str) -> int:
 # be dealt with separately.
 
 BLOCK_SIZE = 1 << 14  # 16KiB, standard across torrents
-FIRST_BYTE_MASK_BY_BIT_ORDER = {i: 0xFF >> i for i in range(0, 8)}
-LAST_BYTE_MASK_BY_BIT_ORDER = {i: 0xFF << 7 - i & 0xFF for i in range(0, 8)}
+FIRST_BYTE_MASK_BY_BIT_ORDER = {i: 0xFF >> i for i in range(8)}
+LAST_BYTE_MASK_BY_BIT_ORDER = {i: 0xFF << 7 - i & 0xFF for i in range(8)}
 
 
 def is_piece_complete(

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -190,6 +190,7 @@ def transmission_get_file_priorities(
 
     files = torrent_info.get(BencodeList, b"files", optional=True)
     if files is None:
+        # Single-file torrent
         file_sizes = [torrent_info.get(int, b"length")]
     else:
         file_sizes = [file.get(int, b"length") for file in files.cast(BencodeDict)]

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from dataclasses import dataclass
+from typing import Literal, cast, overload
 import sys
 import os
 import argparse
@@ -17,7 +19,7 @@ class ConversionError(RuntimeError):
     pass
 
 
-def rm_f(path):
+def rm_f(path: str):
     try:
         os.remove(path)
     except (FileNotFoundError, OSError):
@@ -32,62 +34,167 @@ class QbtUsesSqliteForResumeError(RuntimeError):
     pass
 
 
-def check_for_qbt_sqlite_resume_db(qbt_bt_backup_dir):
+type BencodeType = bytes | int | list[BencodeType] | dict[bytes, BencodeType]
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class BencodeData:
+    path: str
+    data: dict[bytes, BencodeType]
+
+    def _get[T](
+        self, key: bytes, type: type[T], optional: bool, default: T | None
+    ) -> T | None:
+        result = self.data.get(key)
+        if result is None:
+            if optional:
+                return default
+            raise ConversionError(f"{self.path}.{key.decode()} missing")
+
+        if not isinstance(result, type):
+            raise ConversionError(f"{self.path}.{key.decode()} is not {type}")
+        return cast(T, result)
+
+    @overload
+    def get_bytes(self, key: bytes, *, optional: Literal[False] = False) -> bytes: ...
+    @overload
+    def get_bytes(self, key: bytes, *, optional: Literal[True]) -> bytes | None: ...
+    @overload
+    def get_bytes(self, key: bytes, *, default: bytes) -> bytes: ...
+    def get_bytes(
+        self, key: bytes, *, optional: bool = False, default: bytes | None = None
+    ) -> bytes | None:
+        return self._get(key, bytes, optional, default)
+
+    @overload
+    def get_int(self, key: bytes, *, optional: Literal[False] = False) -> int: ...
+    @overload
+    def get_int(self, key: bytes, *, optional: Literal[True]) -> int | None: ...
+    @overload
+    def get_int(self, key: bytes, *, default: int) -> int: ...
+    def get_int(
+        self, key: bytes, *, optional: bool = False, default: int | None = None
+    ) -> int | None:
+        return self._get(key, int, optional, default)
+
+    @overload
+    def get_list(
+        self, key: bytes, *, optional: Literal[False] = False
+    ) -> list[BencodeType]: ...
+    @overload
+    def get_list(
+        self, key: bytes, *, optional: Literal[True]
+    ) -> list[BencodeType] | None: ...
+    def get_list(
+        self, key: bytes, *, optional: bool = False
+    ) -> list[BencodeType] | None:
+        result = self.data.get(key)
+        if result is None:
+            if optional:
+                return None
+            raise ConversionError(f"{self.path}.{key.decode()} missing")
+
+        if not isinstance(result, list):
+            raise ConversionError(f"{self.path}.{key.decode()} is not {type}")
+
+        return result
+
+    @overload
+    def get_dict(
+        self, key: bytes, *, optional: Literal[False] = False
+    ) -> "BencodeData": ...
+    @overload
+    def get_dict(
+        self, key: bytes, *, optional: Literal[True]
+    ) -> "BencodeData | None": ...
+    def get_dict(self, key: bytes, *, optional: bool = False) -> "BencodeData | None":
+        result = self.data.get(key)
+        if result is None:
+            if optional:
+                return None
+            raise ConversionError(f"{self.path}.{key.decode()} missing")
+
+        if not isinstance(result, dict):
+            raise ConversionError(f"{self.path}.{key.decode()} is not {type}")
+
+        return BencodeData(f"{self.path}.{key.decode()}", result)
+
+
+def bencode(data: BencodeType):
+    return bencodepy.bencode(data)  # type: ignore
+
+
+def bdecode(data: bytes) -> BencodeType:
+    return bencodepy.bdecode(data)  # type: ignore
+
+
+def check_for_qbt_sqlite_resume_db(qbt_bt_backup_dir: str):
     torrents_db_path = os.path.join(qbt_bt_backup_dir, "..", "torrents.db")
     if os.path.exists(torrents_db_path):
         raise QbtUsesSqliteForResumeError()
 
 
-def read_bencoded(path):
+def get_data(root: str, path: str):
     with open(path, "rb") as f:
         try:
-            return bencodepy.bdecode(f.read())
+            decoded = bdecode(f.read())
         except (ValueError, bencodepy.BencodeDecodeError) as e:
             raise ReadBencodedError(path) from e
+    if not isinstance(decoded, dict):
+        raise ConversionError(f"{root} is not a dict")
+    return BencodeData(root, decoded)
 
 
 # FIXME BEP0003 says that clients must not perform a decode-encode
 # roundtrip on invalid data. this is exactly what this does.
-def calc_info_hash(parsed_tor):
-    return hashlib.sha1(bencodepy.bencode(parsed_tor[b"info"]))
+def calc_info_hash(parsed_tor: BencodeData):
+    info = parsed_tor.get_dict(b"info")
+    return hashlib.sha1(bencode(info.data))
 
 
-def transmission_get_speed_limit(resume_data, key):
-    speed_limit_obj = resume_data[key]
-    if speed_limit_obj[b"use-speed-limit"] != 0:
-        return speed_limit_obj[b"speed-Bps"]
+def transmission_get_speed_limit(resume_data: BencodeData, key: bytes):
+    speed_limit_obj = resume_data.get_dict(key)
+    if speed_limit_obj.get_int(b"use-speed-limit") != 0:
+        return speed_limit_obj.get_int(b"speed-Bps")
 
     return -1
 
 
-def transmission_get_file_prorities(resume_data):
-    priority = resume_data.get(b"priority")
-    dnd = resume_data.get(b"dnd")
+def transmission_get_file_prorities(resume_data: BencodeData):
+    priority = resume_data.get_list(b"priority", optional=True)
+    dnd = resume_data.get_list(b"dnd", optional=True)
 
     # Return empty list if priority data is not available
     if priority is None or dnd is None:
-        return []
+        return
 
-    rv = []
     if len(priority) != len(dnd):
         raise ConversionError(
             f"priority and dnd lengths are not equal : {len(priority)} != {len(dnd)}"
         )
 
-    for idx, prio in list(enumerate(priority)):
-        if dnd[idx] == 1:
-            rv.append(0)  # libtorrent::dont_download
-        elif prio == -1:  # TR_PRI_LOW
-            rv.append(1)  # libtorrent::low_priority
-        elif prio == 0:  # TR_PRI_NORMAL
-            rv.append(4)  # libtorrent::default_priority
-        elif prio == 1:  # TR_PRI_HIGH
-            rv.append(7)  # libtorrent::top_priority
+    for i, (p, d) in enumerate(zip(priority, dnd, strict=True)):
+        if not isinstance(p, int):
+            raise ConversionError(f"priority[{i}] is not an int")
+        if not isinstance(d, int):
+            raise ConversionError(f"dnd[{i}] is not an int")
+        if d == 1:
+            yield 0  # libtorrent::dont_download
+        else:
+            match p:
+                case -1:  # TR_PRI_LOW
+                    yield 1  # libtorrent::low_priority
+                case 0:  # TR_PRI_NORMAL
+                    yield 4  # libtorrent::default_priority
+                case 1:  # TR_PRI_HIGH
+                    yield 7  # libtorrent::top_priority
+                case _:
+                    raise ConversionError(f"Unknown priority[{i}]: {p}")
 
-    return rv
 
-
-def peers_convert_from_raw_bytes(src, addr_size):
+def peers_convert_from_raw_bytes(src: bytes, addr_size: int):
     rv = bytearray()
     i = 0
     while i < len(src):
@@ -100,96 +207,120 @@ def peers_convert_from_raw_bytes(src, addr_size):
     return bytes(rv)
 
 
-def peers_convert_from_bencoded(src):
+def peers_convert_from_bencoded(src: list[BencodeType], key: bytes):
     # used since Transmission commit 1054ba4 (earliest release - 4.1.0)
     rv = bytearray()
-    for d in src:
-        rv += d[b"socket_address"]
+    for i, d in enumerate(src):
+        if not isinstance(d, dict):
+            raise ConversionError(f"{key}[{i}] is not a dict")
+        socket_address = d[b"socket_address"]
+        if not isinstance(socket_address, bytes):
+            raise ConversionError(f"{key}[{i}].socket_address is not a bytes")
+        rv += socket_address
     return bytes(rv)
 
 
-def transmission_get_peers(resume_data, addr_size, key):
-    src = resume_data.get(key)
+def transmission_get_peers(resume_data: BencodeData, addr_size: int, key: bytes):
+    src = resume_data.data.get(key)
     if src is None:
         return b""
 
     if isinstance(src, list):
-        return peers_convert_from_bencoded(src)
-    else:
+        return peers_convert_from_bencoded(src, key)
+
+    if isinstance(src, bytes):
         return peers_convert_from_raw_bytes(src, addr_size)
 
+    raise ConversionError(f"{key} is not a list or a bytes")
 
-def transmission_get_limit(tr_resume, limit_kind):
+
+def transmission_get_limit(tr_resume: BencodeData, limit_kind: str):
     limit_key = f"{limit_kind}-limit".encode()
     mode_key = f"{limit_kind}-mode".encode()
 
-    limit_obj = tr_resume[limit_key]
-    limit_mode = limit_obj[mode_key]
-    if limit_mode == 0:  # TR_*LIMIT_GLOBAL
-        return "-2"  # BitTorrent::Torrent::USE_GLOBAL_*
-    if limit_mode == 1:  # TR_*LIMIT_SINGLE
-        return limit_obj[limit_key]
-    if limit_mode == 2:  # TR_*LIMIT_UNLIMITED
-        return "-1"  # BitTorrent::Torrent::NO_*_LIMIT
+    limit_obj = tr_resume.get_dict(limit_key)
+    limit_mode = limit_obj.get_int(mode_key)
 
-    raise ConversionError(f"unknown value for {mode_key} : {limit_mode}")
+    match limit_mode:
+        case 0:  # TR_*LIMIT_GLOBAL
+            return -2  # BitTorrent::Torrent::USE_GLOBAL_*
+        case 1:  # TR_*LIMIT_SINGLE
+            return limit_obj.get_int(limit_key)
+        case 2:  # TR_*LIMIT_UNLIMITED
+            return -1  # BitTorrent::Torrent::NO_*_LIMIT
+        case _:
+            raise ConversionError(f"unknown value for {mode_key} : {limit_mode}")
 
 
-def map_resume_to_qbt(resume_data, info_hash):
-    qbt_resume_data = {
-        b"file-format": "libtorrent resume file",
+def map_resume_to_qbt(resume_data: BencodeData, info_hash: str):
+    downloading_time_seconds = resume_data.get_int(b"downloading-time-seconds")
+    seeding_time_seconds = resume_data.get_int(b"seeding-time-seconds")
+
+    qbt_resume_data: BencodeType = {
+        b"file-format": b"libtorrent resume file",
         b"file-version": 1,
         b"info-hash": binascii.unhexlify(info_hash),
-        b"name": resume_data[b"name"],
-        b"total_uploaded": resume_data[b"uploaded"],
-        b"total_downloaded": resume_data[b"downloaded"],
-        b"added_time": resume_data[b"added-date"],
-        b"completed_time": resume_data[b"done-date"],
-        b"active_time": resume_data[b"downloading-time-seconds"]
-        + resume_data[b"seeding-time-seconds"],
-        b"finished_time": resume_data[b"downloading-time-seconds"],
-        b"seeding_time": resume_data[b"seeding-time-seconds"],
-        b"max_connections": resume_data[b"max-peers"],
+        b"name": resume_data.get_bytes(b"name"),
+        b"total_uploaded": resume_data.get_int(b"uploaded"),
+        b"total_downloaded": resume_data.get_int(b"downloaded"),
+        b"added_time": resume_data.get_int(b"added-date"),
+        b"completed_time": resume_data.get_int(b"done-date"),
+        b"active_time": downloading_time_seconds + seeding_time_seconds,
+        b"finished_time": downloading_time_seconds,
+        b"seeding_time": seeding_time_seconds,
+        b"max_connections": resume_data.get_int(b"max-peers"),
         b"upload_rate_limit": transmission_get_speed_limit(
             resume_data, b"speed-limit-up"
         ),
         b"download_rate_limit": transmission_get_speed_limit(
             resume_data, b"speed-limit-down"
         ),
-        b"save_path": resume_data[b"destination"],
-        b"paused": resume_data[b"paused"],
-        b"sequential_download": resume_data.get(b"sequentialDownload", 0),
-        b"file_priority": transmission_get_file_prorities(resume_data),
+        b"save_path": resume_data.get_bytes(b"destination"),
+        b"paused": resume_data.get_int(b"paused"),
+        b"sequential_download": resume_data.get_int(b"sequentialDownload", default=0),
+        b"file_priority": list(transmission_get_file_prorities(resume_data)),
         b"peers": transmission_get_peers(resume_data, 4, b"peers2"),
         b"peers6": transmission_get_peers(resume_data, 16, b"peers2-6"),
-        b"qBt-name": resume_data[b"name"],
+        b"qBt-name": resume_data.get_bytes(b"name"),
         b"qBt-ratioLimit": transmission_get_limit(resume_data, "ratio"),
         b"qBt-inactiveSeedingTimeLimit": int(
             transmission_get_limit(resume_data, "idle")
         ),
-        b"qBt-savePath": resume_data[b"destination"],
+        b"qBt-savePath": resume_data.get_bytes(b"destination"),
     }
 
-    if b"group" in resume_data:
-        qbt_resume_data[b"qBt-category"] = resume_data[b"group"]
+    group = resume_data.get_bytes(b"group", optional=True)
+    if group is not None:
+        qbt_resume_data[b"qBt-category"] = group
 
-    if b"labels" in resume_data:
-        qbt_resume_data[b"qBt-tags"] = (resume_data[b"labels"],)
+    labels = resume_data.get_list(b"labels", optional=True)
+    if labels is not None:
+        qbt_resume_data[b"qBt-tags"] = labels
 
-    if b"files" in resume_data:
-        qbt_resume_data[b"mapped_files"] = resume_data[b"files"]
+    files = resume_data.get_list(b"files", optional=True)
+    if files is not None:
+        qbt_resume_data[b"mapped_files"] = files
 
-    if b"incomplete-dir" in resume_data:
-        qbt_resume_data[b"qBt-downloadPath"] = resume_data[b"incomplete-dir"]
+    incomplete_dir = resume_data.get_bytes(b"incomplete_dir", optional=True)
+    if incomplete_dir is not None:
+        qbt_resume_data[b"qBt-downloadPath"] = incomplete_dir
 
-    if resume_data[b"paused"] == 1:
+    paused = resume_data.get_int(b"paused")
+    if paused == 1:
         qbt_resume_data[b"auto_managed"] = 0
 
     return qbt_resume_data
 
 
+@dataclass(frozen=True)
+class Args:
+    qbt_bt_backup_dir: str
+    transmission_config_dir: str
+    predicate: str | None
+
+
 class TransmissionQbtImporter:
-    def __init__(self, args):
+    def __init__(self, args: Args):
         check_for_qbt_sqlite_resume_db(args.qbt_bt_backup_dir)
         self.source_torrents_dir = os.path.join(
             args.transmission_config_dir, "torrents"
@@ -200,13 +331,15 @@ class TransmissionQbtImporter:
         self.torrent_file_300_rgx = re.compile("([0-9a-f]{40})\\.torrent")
         self.torrent_file_294_rgx = re.compile("\\.[0-9a-f]{16}\\.torrent$")
 
-    def copy_to_target(self, source_tor_abs_path, info_hash, resume_data):
+    def copy_to_target(
+        self, source_tor_abs_path: str, info_hash: str, resume_data: BencodeData
+    ):
         qbt_resume_data = map_resume_to_qbt(resume_data, info_hash)
         qbt_resume_path = os.path.join(self.target_dir, info_hash + ".fastresume")
         qbt_torrent_path = os.path.join(self.target_dir, info_hash + ".torrent")
         try:
             with open(qbt_resume_path, "wb") as resumf:
-                resumf.write(bencodepy.bencode(qbt_resume_data))
+                resumf.write(bencode(qbt_resume_data))
             shutil.copy(source_tor_abs_path, qbt_torrent_path)
             logging.info(
                 f"Successfully imported {os.path.basename(source_tor_abs_path)} ({info_hash})"
@@ -214,19 +347,27 @@ class TransmissionQbtImporter:
 
         except:
             logging.warning(
-                f"Could not copy files for {os.path.basename(source_tor_abs_path)} ({info_hash}) into {qbt_bt_backup_dir}"
+                f"Could not copy files for {os.path.basename(source_tor_abs_path)} ({info_hash}) into {self.target_dir}"
             )
             rm_f(qbt_resume_path)
             rm_f(qbt_torrent_path)
 
-    def copy_if_wanted(self, source_tor_abs_path, parsed_tor, info_hash, resume_data):
+    def copy_if_wanted(
+        self,
+        source_tor_abs_path: str,
+        parsed_tor: BencodeData | None,
+        info_hash: str,
+        resume_data: BencodeData,
+    ):
         if self.predicate is None:
             self.copy_to_target(source_tor_abs_path, info_hash, resume_data)
             return
 
         predicate_rv = None
         parsed_tor = (
-            read_bencoded(source_tor_abs_path) if parsed_tor is None else parsed_tor
+            get_data("torrent", source_tor_abs_path)
+            if parsed_tor is None
+            else parsed_tor
         )
         try:
             predicate_rv = eval(self.predicate)
@@ -243,12 +384,12 @@ class TransmissionQbtImporter:
                 f"Predicate returned {predicate_rv} for torrent {info_hash}, skipping"
             )
 
-    def import_one(self, torf):
+    def import_one(self, torf: str):
         match = self.torrent_file_300_rgx.fullmatch(torf)
         if match:
             info_hash = match[1]
-            resume_data = read_bencoded(
-                os.path.join(self.source_resume_dir, info_hash + ".resume")
+            resume_data = get_data(
+                "resume", os.path.join(self.source_resume_dir, info_hash + ".resume")
             )
             self.copy_if_wanted(
                 os.path.join(self.source_torrents_dir, torf),
@@ -260,13 +401,14 @@ class TransmissionQbtImporter:
 
         match = self.torrent_file_294_rgx.search(torf)
         if match:
-            resume_data = read_bencoded(
+            resume_data = get_data(
+                "resume",
                 os.path.join(
                     self.source_resume_dir, os.path.splitext(torf)[0] + ".resume"
-                )
+                ),
             )
             source_tor_abs_path = os.path.join(self.source_torrents_dir, torf)
-            parsed_tor = read_bencoded(source_tor_abs_path)
+            parsed_tor = get_data("torrent", source_tor_abs_path)
             info_hash = calc_info_hash(parsed_tor).hexdigest()
             self.copy_if_wanted(
                 source_tor_abs_path,
@@ -319,7 +461,7 @@ def main():
         help="A Python expression for filtering source torrents",
     )
 
-    args = parser.parse_args()
+    args = cast(Args, parser.parse_args())
     try:
         TransmissionQbtImporter(args).scan()
     except QbtUsesSqliteForResumeError:

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -51,8 +51,12 @@ def decode(data: bytes) -> BencodeType:
 
 def wrap[T: BencodeWrap](t: type[T], node: BencodeType, path: str) -> T:
     if t is BencodeList:
+        if not isinstance(node, list):
+            raise ConversionError(f"f{path} is not of type list")
         return cast(T, BencodeList(node, path))
     if t is BencodeDict:
+        if not isinstance(node, dict):
+            raise ConversionError(f"f{path} is not of type dict")
         return cast(T, BencodeDict(node, path))
     if not isinstance(node, t):
         raise ConversionError(f"{path} is not of type {T}")
@@ -60,9 +64,7 @@ def wrap[T: BencodeWrap](t: type[T], node: BencodeType, path: str) -> T:
 
 
 class BencodeList:
-    def __init__(self, node: BencodeType, path: str) -> None:
-        if not isinstance(node, list):
-            raise ConversionError(f"f{path} is not of type list")
+    def __init__(self, node: list[BencodeType], path: str) -> None:
         self._node = node
         self._path = path
 
@@ -72,9 +74,7 @@ class BencodeList:
 
 
 class BencodeDict:
-    def __init__(self, node: BencodeType, path: str) -> None:
-        if not isinstance(node, dict):
-            raise ConversionError(f"f{path} is not of type dict")
+    def __init__(self, node: dict[bytes, BencodeType], path: str) -> None:
         self._node = node
         self._path = path
 
@@ -108,9 +108,9 @@ class BencodeDict:
         return encode(self._node)
 
     @staticmethod
-    def decode(encoded: bytes, name: str):
+    def decode(encoded: bytes, name: str) -> "BencodeDict":
         decoded = decode(encoded)
-        return BencodeDict(decoded, name)
+        return wrap(BencodeDict, decoded, name)
 
 
 def check_for_qbt_sqlite_resume_db(qbt_bt_backup_dir: str) -> None:

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -107,14 +107,14 @@ class BencodeDict:
 
     @overload
     def get[T: BencodeWrap](self, t: type[T], key: bytes, *, default: BencodeType) -> T:
-        """Retrieve an item by key and typechecks it. If the key is not present, returns the provided default."""
+        """Retrieves an item by key and typechecks it. If the key is not present, returns the provided default."""
         ...
 
     @overload
     def get[T: BencodeWrap](
         self, t: type[T], key: bytes, *, optional: Literal[True]
     ) -> None | T:
-        """Retrieve an item by key and typechecks it. If the key is not present, returns None."""
+        """Retrieves an item by key and typechecks it. If the key is not present, returns None."""
         ...
 
     def get[T: BencodeWrap](
@@ -302,7 +302,7 @@ def transmission_get_limit(resume: BencodeDict, limit_kind: str) -> int:
 # All the tr_blocks bytes between the first and the last are fully part of the piece, so if the piece is complete the block bytes are all
 # 0xff. No need to mask for these, we can just compare them all to 0xff.
 #
-# There is a special case when a piece is fully contained within a block byte (which only happens when the piece length is <= 8*16KiB).
+# There is a special case when a piece is fully contained within a block byte (which only happens when the piece size is <= 8*16KiB).
 # In this case there is only one block byte to check and we need to mask it against both the start and end mask.
 #
 # We also need to take in account that the total number of blocks might not align with the end of a piece, i.e. the last piece can be smaller.
@@ -327,7 +327,7 @@ def is_piece_complete(
     piece_start_in_overall_blocks = piece_index * blocks_per_piece
     # In tr_blocks
     piece_start_in_block_bytes = piece_start_in_overall_blocks // 8
-    # in the specific tr_blocks byte
+    # In the specific tr_blocks byte
     piece_start_bit_order = piece_start_in_overall_blocks % 8
 
     # Indexes of the last block of the piece
@@ -337,7 +337,7 @@ def is_piece_complete(
     )
     # In tr_blocks
     piece_end_in_block_bytes = piece_end_in_overall_blocks // 8
-    # in the specific tr_blocks byte
+    # In the specific tr_blocks byte
     piece_end_bit_order = piece_end_in_overall_blocks % 8
 
     num_piece_bytes = piece_end_in_block_bytes - piece_start_in_block_bytes + 1
@@ -413,18 +413,26 @@ def transmission_get_pieces(torrent: BencodeDict, resume: BencodeDict) -> bytes:
 def transmission_get_files(
     torrent_info: BencodeDict, resume: BencodeDict
 ) -> None | list[BencodeType]:
+    # When adding a torrent to Transmission, the resume name is initially set to the same as
+    # the name defined in the torrent. It diverges when renaming the torrent inside Transmission.
+    # This action also renames the file (for single-file torrents) or top-level directory
+    # (multi-file torrents).
+    tr_name = resume.get(bytes, b"name")
+
     # Files as defined in the torrent
     tor_files = torrent_info.get(BencodeList, b"files", optional=True)
+    if tor_files is None:
+        # Single-file torrent, return the resume name,
+        return [tr_name]
 
     # Files as defined in the Transmission resume
-    tr_name = resume.get(bytes, b"name")
     tr_files = resume.get(BencodeList, b"files", optional=True)
-
-    if tor_files is None or tr_files is None:
-        # Single-file torrent
+    if tr_files is None:
+        # If we do not have access to this data, None is valid for qBittorrent as it will use the
+        # default names (the ones defined in the torrent)
         return None
 
-    # Files as defined in the qBittorrent resume
+    # Files as defined in the qBittorrent resume (what we are calculating)
     qbit_files = list[BencodeType]()
 
     tr_index = 0

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -179,7 +179,7 @@ def transmission_get_file_priorities(
     priorities = resume.get(BencodeList, b"priority", optional=True)
     dnds = resume.get(BencodeList, b"dnd", optional=True)
 
-    # Return empty list if priority data is not available
+    # Return empty generator if priority data is not available
     if priorities is None or dnds is None:
         return
 

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -388,12 +388,12 @@ def transmission_get_pieces(torrent: BencodeDict, resume: BencodeDict) -> bytes:
 
 
 def map_resume_to_qbt(
-    info_hash: str, torrent: BencodeDict, resume: BencodeDict
+    info_hash: str, torrent: BencodeDict, resume: BencodeDict, add_paused: bool
 ) -> dict[bytes, BencodeType]:
     downloading_time_seconds = resume.get(int, b"downloading-time-seconds")
     seeding_time_seconds = resume.get(int, b"seeding-time-seconds")
     name = resume.get(bytes, b"name")
-    paused = resume.get(int, b"paused")
+    paused = add_paused or resume.get(int, b"paused")
 
     qbt_resume_data: BencodeType = {
         b"file-format": b"libtorrent resume file",
@@ -455,7 +455,8 @@ def map_resume_to_qbt(
 class Args:
     qbt_bt_backup_dir: str
     transmission_config_dir: str
-    predicate: str | None
+    filter: str | None
+    add_paused: bool
     dry_run: bool
     log_level: int
 
@@ -468,7 +469,8 @@ class TransmissionQbtImporter:
         )
         self._source_resume_dir = os.path.join(args.transmission_config_dir, "resume")
         self._target_dir = args.qbt_bt_backup_dir
-        self._predicate = args.predicate
+        self._filter = args.filter
+        self._add_paused = args.add_paused
         self._dry_run = args.dry_run
         self._torrent_file_300_rgx = re.compile("([0-9a-f]{40})\\.torrent")
         self._torrent_file_294_rgx = re.compile("\\.[0-9a-f]{16}\\.torrent$")
@@ -480,7 +482,9 @@ class TransmissionQbtImporter:
         torrent: BencodeDict,
         resume: BencodeDict,
     ) -> None:
-        qbt_resume_data = map_resume_to_qbt(info_hash, torrent, resume)
+        qbt_resume_data = map_resume_to_qbt(
+            info_hash, torrent, resume, self._add_paused
+        )
         qbt_resume_enc = encode(qbt_resume_data)
         qbt_resume_path = os.path.join(self._target_dir, info_hash + ".fastresume")
         qbt_torrent_path = os.path.join(self._target_dir, info_hash + ".torrent")
@@ -520,11 +524,11 @@ class TransmissionQbtImporter:
         if info_hash is None:
             info_hash = calc_info_hash(torrent)
 
-        if self._predicate is None:
+        if self._filter is None:
             predicate_rv = True
         else:
             try:
-                predicate_rv = eval(self._predicate)
+                predicate_rv = eval(self._filter)
             except Exception as e:
                 logging.info(
                     f"Predicate threw {type(e).__name__} with {e} for torrent {info_hash}, skipping"
@@ -534,7 +538,7 @@ class TransmissionQbtImporter:
         if predicate_rv:
             self.copy_to_target(source_tor_abs_path, info_hash, torrent, resume)
         else:
-            logging.info(
+            logging.debug(
                 f"Predicate returned {predicate_rv} for torrent {info_hash}, skipping"
             )
 
@@ -595,9 +599,15 @@ def main() -> int:
         help="The BT_backup directory inside target qBittorrent instance's data directory",
     )
     parser.add_argument(
-        "--predicate",
-        "-p",
+        "--filter",
+        "-f",
         help="A Python expression for filtering source torrents",
+    )
+    parser.add_argument(
+        "--add-paused",
+        "-p",
+        action="store_true",
+        help="Optional flag to add all torrents paused rather than using the resume status",
     )
     parser.add_argument(
         "--dry-run",

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -66,7 +66,7 @@ class BencodeListWrapper[T: bytes | int](Iterator[T]):
             raise StopIteration
 
         if not isinstance(next_item, self._item_type):
-            raise ConversionError(f"{self._path}[{self._index}] is not bytes")
+            raise ConversionError(f"{self._path}[{self._index}] is not {T}")
         return next_item
 
 
@@ -86,7 +86,7 @@ class BencodeDictWrapper:
     ) -> T | None: ...
     @overload
     def get[T: bytes | int](self, type: type[T], key: bytes, *, default: T) -> T: ...
-    def get[T: bytes | int](
+    def get[T](
         self,
         type: type[T],
         key: bytes,

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 from dataclasses import dataclass
-from typing import Literal, cast, get_origin, overload
+from typing import Literal, NamedTuple, cast, get_origin, overload
 from collections.abc import Generator
 import sys
 import os
@@ -35,58 +35,66 @@ class QbtUsesSqliteForResumeError(RuntimeError):
     pass
 
 
-type BencodeList = list["BencodeType"]
-type BencodeDict = dict[bytes, "BencodeType"]
+type BencodeList = list[BencodeType]
+type BencodeDict = dict[bytes, BencodeType]
 type BencodeType = bytes | int | BencodeList | BencodeDict
 
 
-def safe_cast[T: BencodeType](
-    type_dest: type[T], error_path: str, value: BencodeType
-) -> T:
+@dataclass(frozen=True)
+class BencodeNode[T: BencodeType](NamedTuple):
+    # A class for convenience, which carries the full path of the node
+    # e.g. value=xxx, path="torrent.info.length"
+    value: T
+    path: str
+
+
+type BencodeDictNode = BencodeNode[BencodeDict]
+
+
+def build_bencode_node[T: BencodeType](
+    type_dest: type[T], value: BencodeType, path: str
+) -> BencodeNode[T]:
     # origin is the parent class for generics (e.g. list for list[int])
     # origin is none for non-generics
     # isinstance does not work on generics but it works on the origin of a generic
     # cast works on the generic itself so type inference works
     typecheck = get_origin(type_dest) or type_dest
     if not isinstance(value, typecheck):
-        raise ConversionError(f"f{error_path} is not of type {typecheck}")
-    return cast(T, value)
+        raise ConversionError(f"f{path} is not of type {typecheck}")
+    return BencodeNode(cast(T, value), path)
 
 
 @overload
 def get[T: BencodeType](
     type_dest: type[T],
-    error_path: str,
-    data: BencodeDict,
+    data: BencodeNode[BencodeDict],
     key: bytes,
     *,
     default: T | None = None,
-) -> T: ...
+) -> BencodeNode[T]: ...
 @overload
 def get[T: BencodeType](
     type_dest: type[T],
-    error_path: str,
-    data: BencodeDict,
+    data: BencodeNode[BencodeDict],
     key: bytes,
     *,
     optional: Literal[True],
-) -> T | None: ...
+) -> BencodeNode[T] | None: ...
 def get[T: BencodeType](
     type_dest: type[T],
-    error_path: str,
-    data: BencodeDict,
+    data: BencodeNode[BencodeDict],
     key: bytes,
     *,
     default: T | None = None,
     optional: bool = False,
-) -> T | None:
-    error_path = f"{error_path}.{key.decode()}"
-    value = data.get(key, default)
+) -> BencodeNode[T] | None:
+    value = data.value.get(key, default)
+    path = f"{data.path}.{key.decode()}"
     if value is None:
         if optional:
             return None
-        raise ConversionError(f"{error_path} is missing")
-    return safe_cast(type_dest, error_path, value)
+        raise ConversionError(f"{path} is missing")
+    return build_bencode_node(type_dest, value, path)
 
 
 def bencode(data: BencodeType) -> bytes:
@@ -103,40 +111,41 @@ def check_for_qbt_sqlite_resume_db(qbt_bt_backup_dir: str) -> None:
         raise QbtUsesSqliteForResumeError()
 
 
-def get_data(error_path: str, path: str) -> BencodeDict:
-    with open(path, "rb") as f:
+def get_data(root_path: str, file_path: str) -> BencodeDictNode:
+    with open(file_path, "rb") as f:
         try:
             decoded = bdecode(f.read())
         except (ValueError, bencodepy.BencodeDecodeError) as e:
-            raise ReadBencodedError(path) from e
-    return safe_cast(dict[bytes, BencodeType], error_path, decoded)
+            raise ReadBencodedError(file_path) from e
+    return build_bencode_node(dict[bytes, BencodeType], decoded, root_path)
 
 
 # FIXME BEP0003 says that clients must not perform a decode-encode
 # roundtrip on invalid data. this is exactly what this does.
-def calc_info_hash(parsed_tor: BencodeDict) -> str:
-    info = get(dict[bytes, BencodeType], "torrent", parsed_tor, b"info")
+def calc_info_hash(parsed_tor: BencodeDictNode) -> str:
+    info, _ = get(dict[bytes, BencodeType], parsed_tor, b"info")
     return hashlib.sha1(bencode(info)).hexdigest()
 
 
-def transmission_get_speed_limit(resume_data: BencodeDict, key: bytes) -> int:
-    speed_limit_obj = get(dict[bytes, BencodeType], "resume", resume_data, key)
-    speed_limit_path = f"resume.{key.decode()}"
-    use_speed_limit = get(int, speed_limit_path, speed_limit_obj, b"use-speed-limit")
+def transmission_get_speed_limit(resume_data: BencodeDictNode, key: bytes) -> int:
+    speed_limit_obj = get(dict[bytes, BencodeType], resume_data, key)
+    use_speed_limit, _ = get(int, speed_limit_obj, b"use-speed-limit")
     if use_speed_limit != 0:
-        return get(int, speed_limit_path, speed_limit_obj, b"speed-Bps")
+        return get(int, speed_limit_obj, b"speed-Bps").value
 
     return -1
 
 
-def transmission_get_file_prorities(resume_data: BencodeDict) -> Generator[int]:
-    priority = get(list[BencodeType], "resume", resume_data, b"priority", optional=True)
-    dnd = get(list[BencodeType], "resume", resume_data, b"dnd", optional=True)
+def transmission_get_file_prorities(resume_data: BencodeDictNode) -> Generator[int]:
+    priority_node = get(list[BencodeType], resume_data, b"priority", optional=True)
+    dnd_node = get(list[BencodeType], resume_data, b"dnd", optional=True)
 
     # Return empty list if priority data is not available
-    if priority is None or dnd is None:
+    if priority_node is None or dnd_node is None:
         return
 
+    priority = priority_node.value
+    dnd = dnd_node.value
     if len(priority) != len(dnd):
         raise ConversionError(
             f"priority and dnd lengths are not equal : {len(priority)} != {len(dnd)}"
@@ -175,16 +184,16 @@ def peers_convert_from_bencoded(src: BencodeList, key: bytes) -> bytes:
     rv = bytearray()
     for i, d in enumerate(src):
         d_path = f"{key}[{i}]"
-        d_dict = safe_cast(dict[bytes, BencodeType], d_path, d)
-        socket_address = get(bytes, d_path, d_dict, b"socket_address")
+        d_dict = build_bencode_node(dict[bytes, BencodeType], d, d_path)
+        socket_address = get(bytes, d_dict, b"socket_address").value
         rv += socket_address
     return bytes(rv)
 
 
 def transmission_get_peers(
-    resume_data: BencodeDict, addr_size: int, key: bytes
+    resume_data: BencodeDictNode, addr_size: int, key: bytes
 ) -> bytes:
-    src = resume_data.get(key)
+    src = resume_data.value.get(key)
     if src is None:
         return b""
 
@@ -197,19 +206,18 @@ def transmission_get_peers(
     raise ConversionError(f"{key} is not a list or bytes")
 
 
-def transmission_get_limit(tr_resume: BencodeDict, limit_kind: str) -> int:
+def transmission_get_limit(tr_resume: BencodeDictNode, limit_kind: str) -> int:
     limit_key = f"{limit_kind}-limit".encode()
-    limit_obj = get(dict[bytes, BencodeType], "resume", tr_resume, limit_key)
+    limit_obj = get(dict[bytes, BencodeType], tr_resume, limit_key)
 
     mode_key = f"{limit_kind}-mode".encode()
-    limit_path = f"resume.{limit_key}"
-    limit_mode = get(int, limit_path, limit_obj, mode_key)
+    limit_mode, _ = get(int, limit_obj, mode_key)
 
     match limit_mode:
         case 0:  # TR_*LIMIT_GLOBAL
             return -2  # BitTorrent::Torrent::USE_GLOBAL_*
         case 1:  # TR_*LIMIT_SINGLE
-            return get(int, limit_path, limit_obj, limit_key)
+            return get(int, limit_obj, limit_key).value
         case 2:  # TR_*LIMIT_UNLIMITED
             return -1  # BitTorrent::Torrent::NO_*_LIMIT
         case _:
@@ -248,10 +256,12 @@ def get_last_piece_mask_for_block_checking(torrent_size: int, piece_size: int) -
     return piece_mask
 
 
-def transmission_get_pieces(parsed_tor: BencodeDict, tr_resume: BencodeDict) -> bytes:
-    info = get(dict[bytes, BencodeType], "torrent", parsed_tor, b"info")
-    torrent_size = get(int, "torrent.info", info, b"length")
-    piece_size = get(int, "torrent.info", info, b"piece length")
+def transmission_get_pieces(
+    parsed_tor: BencodeDictNode, tr_resume: BencodeDictNode
+) -> bytes:
+    info = get(dict[bytes, BencodeType], parsed_tor, b"info")
+    torrent_size, _ = get(int, info, b"length")
+    piece_size, _ = get(int, info, b"piece length")
 
     # Sanity check the piece length
     # Only accept piece size in powers of 2
@@ -267,8 +277,8 @@ def transmission_get_pieces(parsed_tor: BencodeDict, tr_resume: BencodeDict) -> 
     if piece_size < 1 << 17:  # 128KiB
         raise ConversionError(f"Piece size {piece_size} is lower than 128KiB, aborting")
 
-    progress = get(dict[bytes, BencodeType], "resume", tr_resume, b"progress")
-    blocks = get(bytes, "resume.progress", progress, b"blocks")
+    progress = get(dict[bytes, BencodeType], tr_resume, b"progress")
+    blocks, _ = get(bytes, progress, b"blocks")
 
     # Sanity check the block bytes length
     # ceiling integer division
@@ -309,39 +319,37 @@ def transmission_get_pieces(parsed_tor: BencodeDict, tr_resume: BencodeDict) -> 
 
 
 def map_resume_to_qbt(
-    info_hash: str, parsed_tor: BencodeDict, resume_data: BencodeDict
+    info_hash: str, parsed_tor: BencodeDictNode, resume_data: BencodeDictNode
 ) -> BencodeDict:
-    downloading_time_seconds = get(
-        int, "resume", resume_data, b"downloading-time-seconds"
-    )
-    seeding_time_seconds = get(int, "resume", resume_data, b"seeding-time-second")
-    name = get(bytes, "resume", resume_data, b"name")
-    paused = get(int, "resume", resume_data, b"paused")
+    downloading_time_seconds, _ = get(int, resume_data, b"downloading-time-seconds")
+    seeding_time_seconds, _ = get(int, resume_data, b"seeding-time-second")
+    name, _ = get(bytes, resume_data, b"name")
+    paused, __ = get(int, resume_data, b"paused")
 
     qbt_resume_data: BencodeType = {
         b"file-format": b"libtorrent resume file",
         b"file-version": 1,
         b"info-hash": binascii.unhexlify(info_hash),
         b"name": name,
-        b"total_uploaded": get(int, "resume", resume_data, b"uploaded"),
-        b"total_downloaded": get(int, "resume", resume_data, b"downloaded"),
-        b"added_time": get(int, "resume", resume_data, b"added-date"),
-        b"completed_time": get(int, "resume", resume_data, b"done-date"),
+        b"total_uploaded": get(int, resume_data, b"uploaded").value,
+        b"total_downloaded": get(int, resume_data, b"downloaded").value,
+        b"added_time": get(int, resume_data, b"added-date").value,
+        b"completed_time": get(int, resume_data, b"done-date").value,
         b"active_time": downloading_time_seconds + seeding_time_seconds,
         b"finished_time": downloading_time_seconds,
         b"seeding_time": seeding_time_seconds,
-        b"max_connections": get(int, "resume", resume_data, b"max-peers"),
+        b"max_connections": get(int, resume_data, b"max-peers").value,
         b"upload_rate_limit": transmission_get_speed_limit(
             resume_data, b"speed-limit-up"
         ),
         b"download_rate_limit": transmission_get_speed_limit(
             resume_data, b"speed-limit-down"
         ),
-        b"save_path": get(bytes, "resume", resume_data, b"destination"),
+        b"save_path": get(bytes, resume_data, b"destination").value,
         b"paused": paused,
         b"sequential_download": get(
-            int, "resume", resume_data, b"sequentialDownload", default=0
-        ),
+            int, resume_data, b"sequentialDownload", default=0
+        ).value,
         b"file_priority": list(transmission_get_file_prorities(resume_data)),
         b"peers": transmission_get_peers(resume_data, 4, b"peers2"),
         b"peers6": transmission_get_peers(resume_data, 16, b"peers2-6"),
@@ -350,25 +358,25 @@ def map_resume_to_qbt(
         b"qBt-inactiveSeedingTimeLimit": int(
             transmission_get_limit(resume_data, "idle")
         ),
-        b"qBt-savePath": get(bytes, "resume", resume_data, b"destination"),
+        b"qBt-savePath": get(bytes, resume_data, b"destination").value,
         b"pieces": transmission_get_pieces(parsed_tor, resume_data),
     }
 
-    group = get(bytes, "resume", resume_data, b"group", optional=True)
+    group = get(bytes, resume_data, b"group", optional=True)
     if group is not None:
-        qbt_resume_data[b"qBt-category"] = group
+        qbt_resume_data[b"qBt-category"] = group.value
 
-    labels = get(list[BencodeType], "resume", resume_data, b"labels", optional=True)
+    labels = get(list[BencodeType], resume_data, b"labels", optional=True)
     if labels is not None:
-        qbt_resume_data[b"qBt-tags"] = labels
+        qbt_resume_data[b"qBt-tags"] = labels.value
 
-    files = get(list[BencodeType], "resume", resume_data, b"files", optional=True)
+    files = get(list[BencodeType], resume_data, b"files", optional=True)
     if files is not None:
-        qbt_resume_data[b"mapped_files"] = files
+        qbt_resume_data[b"mapped_files"] = files.value
 
-    incomplete_dir = get(bytes, "resume", resume_data, b"incomplete_dir", optional=True)
+    incomplete_dir = get(bytes, resume_data, b"incomplete_dir", optional=True)
     if incomplete_dir is not None:
-        qbt_resume_data[b"qBt-downloadPath"] = incomplete_dir
+        qbt_resume_data[b"qBt-downloadPath"] = incomplete_dir.value
 
     if paused == 1:
         qbt_resume_data[b"auto_managed"] = 0
@@ -399,8 +407,8 @@ class TransmissionQbtImporter:
         self,
         source_tor_abs_path: str,
         info_hash: str,
-        parsed_tor: BencodeDict,
-        resume_data: BencodeDict,
+        parsed_tor: BencodeDictNode,
+        resume_data: BencodeDictNode,
     ) -> None:
         qbt_resume_data = map_resume_to_qbt(info_hash, parsed_tor, resume_data)
         qbt_resume_path = os.path.join(self.target_dir, info_hash + ".fastresume")

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -94,7 +94,7 @@ class BencodeList:
 
 
 class BencodeDict:
-    """Wraps a bencode dict. Allows retrieving items by key."""
+    """Wraps a bencode dict. Allows retrieving items by key while typechecking them."""
 
     def __init__(self, node: dict[bytes, BencodeType], path: str) -> None:
         self._node = node
@@ -102,19 +102,19 @@ class BencodeDict:
 
     @overload
     def get[T: BencodeWrap](self, t: type[T], key: bytes) -> T:
-        """Retrieve an item by key. If the key is not present, raises ConversionError."""
+        """Retrieves an item by key and typechecks it. If the key is not present, raises ConversionError."""
         ...
 
     @overload
     def get[T: BencodeWrap](self, t: type[T], key: bytes, *, default: BencodeType) -> T:
-        """Retrieve an item by key. If the key is not present, returns the provided default."""
+        """Retrieve an item by key and typechecks it. If the key is not present, returns the provided default."""
         ...
 
     @overload
     def get[T: BencodeWrap](
         self, t: type[T], key: bytes, *, optional: Literal[True]
     ) -> None | T:
-        """Retrieve an item by key. If the key is not present, returns None."""
+        """Retrieve an item by key and typechecks it. If the key is not present, returns None."""
         ...
 
     def get[T: BencodeWrap](

--- a/transmission2qbt.py
+++ b/transmission2qbt.py
@@ -36,8 +36,6 @@ class QbtUsesSqliteForResumeError(RuntimeError):
 
 type BencodeType = bytes | int | list[BencodeType] | dict[bytes, BencodeType]
 
-from dataclasses import dataclass
-
 
 @dataclass(frozen=True)
 class BencodeData:
@@ -49,7 +47,7 @@ class BencodeData:
     ) -> T | None:
         result = self.data.get(key)
         if result is None:
-            if optional:
+            if optional or default is not None:
                 return default
             raise ConversionError(f"{self.path}.{key.decode()} missing")
 
@@ -252,15 +250,33 @@ def transmission_get_limit(tr_resume: BencodeData, limit_kind: str):
             raise ConversionError(f"unknown value for {mode_key} : {limit_mode}")
 
 
-def map_resume_to_qbt(resume_data: BencodeData, info_hash: str):
+BIT_LOOKUP = [bytes(n >> i & 1 for i in range(7, -1, -1)) for n in range(256)]
+
+
+def transmission_get_pieces(tr_resume: BencodeData, num_pieces: int):
+    tr_piece_bytes = tr_resume.get_dict(b"progress").get_bytes(b"pieces")
+    match tr_piece_bytes:
+        case b"all":
+            return b"\1" * num_pieces
+        case b"none":
+            return b"\0" * num_pieces
+        case _:
+            qb_pieces = bytearray()
+            for tr_piece_byte in tr_piece_bytes:
+                qb_pieces += BIT_LOOKUP[tr_piece_byte]
+            return bytes(qb_pieces[:num_pieces].ljust(num_pieces, b"\0"))
+
+
+def map_resume_to_qbt(resume_data: BencodeData, info_hash: str, num_pieces: int):
     downloading_time_seconds = resume_data.get_int(b"downloading-time-seconds")
     seeding_time_seconds = resume_data.get_int(b"seeding-time-seconds")
+    name = resume_data.get_bytes(b"name")
 
     qbt_resume_data: BencodeType = {
         b"file-format": b"libtorrent resume file",
         b"file-version": 1,
         b"info-hash": binascii.unhexlify(info_hash),
-        b"name": resume_data.get_bytes(b"name"),
+        b"name": name,
         b"total_uploaded": resume_data.get_int(b"uploaded"),
         b"total_downloaded": resume_data.get_int(b"downloaded"),
         b"added_time": resume_data.get_int(b"added-date"),
@@ -281,7 +297,7 @@ def map_resume_to_qbt(resume_data: BencodeData, info_hash: str):
         b"file_priority": list(transmission_get_file_prorities(resume_data)),
         b"peers": transmission_get_peers(resume_data, 4, b"peers2"),
         b"peers6": transmission_get_peers(resume_data, 16, b"peers2-6"),
-        b"qBt-name": resume_data.get_bytes(b"name"),
+        b"qBt-name": name,
         b"qBt-ratioLimit": transmission_get_limit(resume_data, "ratio"),
         b"qBt-inactiveSeedingTimeLimit": int(
             transmission_get_limit(resume_data, "idle")
@@ -309,6 +325,8 @@ def map_resume_to_qbt(resume_data: BencodeData, info_hash: str):
     if paused == 1:
         qbt_resume_data[b"auto_managed"] = 0
 
+    qbt_resume_data[b"pieces"] = transmission_get_pieces(resume_data, num_pieces)
+
     return qbt_resume_data
 
 
@@ -332,9 +350,13 @@ class TransmissionQbtImporter:
         self.torrent_file_294_rgx = re.compile("\\.[0-9a-f]{16}\\.torrent$")
 
     def copy_to_target(
-        self, source_tor_abs_path: str, info_hash: str, resume_data: BencodeData
+        self,
+        source_tor_abs_path: str,
+        info_hash: str,
+        num_pieces: int,
+        resume_data: BencodeData,
     ):
-        qbt_resume_data = map_resume_to_qbt(resume_data, info_hash)
+        qbt_resume_data = map_resume_to_qbt(resume_data, info_hash, num_pieces)
         qbt_resume_path = os.path.join(self.target_dir, info_hash + ".fastresume")
         qbt_torrent_path = os.path.join(self.target_dir, info_hash + ".torrent")
         try:
@@ -355,30 +377,31 @@ class TransmissionQbtImporter:
     def copy_if_wanted(
         self,
         source_tor_abs_path: str,
-        parsed_tor: BencodeData | None,
-        info_hash: str,
-        resume_data: BencodeData,
+        source_res_abs_path: str,
+        info_hash: str | None,
     ):
-        if self.predicate is None:
-            self.copy_to_target(source_tor_abs_path, info_hash, resume_data)
-            return
+        parsed_tor = get_data("torrent", source_tor_abs_path)
 
-        predicate_rv = None
-        parsed_tor = (
-            get_data("torrent", source_tor_abs_path)
-            if parsed_tor is None
-            else parsed_tor
-        )
-        try:
-            predicate_rv = eval(self.predicate)
-        except Exception as e:
-            logging.info(
-                f"Predicate threw {type(e).__name__} with {e} for torrent {info_hash}, skipping"
-            )
-            return
+        resume_data = get_data("resume", source_res_abs_path)
+
+        if info_hash is None:
+            info_hash = calc_info_hash(parsed_tor).hexdigest()
+
+        num_pieces = len(parsed_tor.get_dict(b"info").get_list(b"pieces")) // 20
+
+        if self.predicate is None:
+            predicate_rv = True
+        else:
+            try:
+                predicate_rv = eval(self.predicate)
+            except Exception as e:
+                logging.info(
+                    f"Predicate threw {type(e).__name__} with {e} for torrent {info_hash}, skipping"
+                )
+                return
 
         if predicate_rv is True:
-            self.copy_to_target(source_tor_abs_path, info_hash, resume_data)
+            self.copy_to_target(source_tor_abs_path, info_hash, num_pieces, resume_data)
         else:
             logging.info(
                 f"Predicate returned {predicate_rv} for torrent {info_hash}, skipping"
@@ -388,33 +411,21 @@ class TransmissionQbtImporter:
         match = self.torrent_file_300_rgx.fullmatch(torf)
         if match:
             info_hash = match[1]
-            resume_data = get_data(
-                "resume", os.path.join(self.source_resume_dir, info_hash + ".resume")
-            )
             self.copy_if_wanted(
                 os.path.join(self.source_torrents_dir, torf),
-                None,
-                info_hash,
-                resume_data,
+                os.path.join(self.source_resume_dir, info_hash + ".resume"),
+                match[1],
             )
             return
 
         match = self.torrent_file_294_rgx.search(torf)
         if match:
-            resume_data = get_data(
-                "resume",
+            self.copy_if_wanted(
+                os.path.join(self.source_torrents_dir, torf),
                 os.path.join(
                     self.source_resume_dir, os.path.splitext(torf)[0] + ".resume"
                 ),
-            )
-            source_tor_abs_path = os.path.join(self.source_torrents_dir, torf)
-            parsed_tor = get_data("torrent", source_tor_abs_path)
-            info_hash = calc_info_hash(parsed_tor).hexdigest()
-            self.copy_if_wanted(
-                source_tor_abs_path,
-                parsed_tor,
-                info_hash,
-                resume_data,
+                None,
             )
             return
 


### PR DESCRIPTION
I have just completed a large migration using the script, here is a PR containing various improvements I wrote along the way, if you are interested in merging them.

# Bug fixes

- 0-sized files defined in .torrent files are ignored by Transmission, but not qBittorrent. This means than resume lists that are implicitly indexed based on the .torrent files will be missing these files in the Transmission resume but should not be missing in the qBittorrent resume. This PR fixes issues in the following qBittorrent properties:
  - `mapped_files`
  - `file_priority`

# Added features

- Added calculation of the completion status of the torrents in qBittorrent, i.e. the `pieces` property. It does not calculate incomplete pieces, i.e. the `unfinished` property. Added an explanation to the README as to why, and extensive explanation of the algorithm to the script itself.
- Skips peer migration for private torrents. By the convention on the private flag, clients will disable DHT / PEX / Local Peer Discovery, and therefore rely on a working tracker, which will provide a fresh peer list when qBittorrent first announces after migration.

# User experience

- Added a `--dry-run`/`-d` parameter to test a migration without writing any .torrent or .resume file to the output.
- Added a `--log-level`/`-l` parameter to configure which messages are shown (see [Python definition](https://docs.python.org/3/library/logging.html#logging-levels)). Also reviewed all the messages for better ux e.g. avoid logging info for each torrent, which makes the output illisible for large migrations.
- Added an `--add-paused`/`-p` parameter to optionnally force all output torrents to be paused in the qBittorrent output. This is to allow testing the migration without accidentally starting all torrents i.e. in case of path misconfiguration.
- Renamed the `--predicate` parameter to `--filter` and added the `-f` alias. The syntax of the filters will need to change in existing script usage due to the changes in the internal data representation.
- Added summary (success / failure / skip).

# Developer experience

- Added type hinting and formatting to the script (I use Pylance for code analysis and Black Formatter for code formatting), via the introduction of the `BencodeType` alias to represent the bencode tree structure, and the `BencodeDict` / `BencodeList` wrappers to perform operations on nodes that allow strict type checking at runtime on all the fields being read in the bencode data. This will hopefully allow catching schema inconsistencies earlier in the data processing flow rather than potentially copying unexpected structures.
  - `bencode.py` does not provide type hints, so the code wraps the two functions we use to force type hinting on them.
  - The syntax used (in particular generics) means that Python 3.12+ is required.
- Added VS Code debugging configuration.

# Implementation & testing

This was tested successfully on Transmission 4.0.5 & qBittorrent 5.1.4 / libtorrent 1.2.20
I measured the speed at about 2000 torrents/s (on an SSD) so it should be enough for most use cases
No AI was used to write the code
Sorry about the large number of commits, I worked without branching on my fork